### PR TITLE
Add GitHub reporter format

### DIFF
--- a/packages/reporter/src/index.test.ts
+++ b/packages/reporter/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createScanResultSkeleton } from "@next-secure-check/core";
-import { formatMarkdown, formatReport, formatSummary, formatTerminal } from "./index.js";
+import { formatGithub, formatMarkdown, formatReport, formatSummary, formatTerminal } from "./index.js";
 
 describe("formatSummary", () => {
   it("renders the scan score and risk level", () => {
@@ -22,9 +22,53 @@ describe("formatSummary", () => {
     expect(formatMarkdown(result)).toContain("# next-secure-check report");
   });
 
+  it("renders github reports as a compact summary table", () => {
+    const result = createScanResultSkeleton("demo-app");
+    result.project.framework = "nextjs";
+    result.summary = {
+      score: 72,
+      riskLevel: "high",
+      totalFindings: 1,
+      high: 1,
+      medium: 0,
+      low: 0,
+      info: 0
+    };
+    result.findings = [
+      {
+        id: "finding-1",
+        ruleId: "secrets/hardcoded-secret",
+        title: "Possible hardcoded secret detected",
+        severity: "HIGH",
+        confidence: "HIGH",
+        category: "secrets",
+        filePath: "app/api/login/route.ts",
+        line: 12,
+        description: "A secret-like value appears in source code.",
+        recommendation: "Move secrets to environment variables and rotate exposed values."
+      }
+    ];
+
+    const githubReport = formatGithub(result);
+
+    expect(githubReport).toContain("## next-secure-check");
+    expect(githubReport).toContain("| Metric | Value |");
+    expect(githubReport).toContain("| HIGH | `secrets/hardcoded-secret` | Possible hardcoded secret detected | `app/api/login/route.ts:12` | HIGH |");
+    expect(githubReport).toContain("<summary>Recommendations</summary>");
+    expect(formatReport(result, "github")).toBe(githubReport);
+    expect(githubReport).not.toBe(formatMarkdown(result));
+  });
+
   it("renders terminal reports with no findings", () => {
     const result = createScanResultSkeleton("demo-app");
 
     expect(formatTerminal(result)).toContain("No findings detected.");
+  });
+
+  it("renders github reports with no findings", () => {
+    const result = createScanResultSkeleton("demo-app");
+
+    expect(formatGithub(result)).toContain("**Status:** No findings");
+    expect(formatGithub(result)).toContain("No findings detected.");
   });
 });

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -9,8 +9,9 @@ export function formatReport(result: ScanResult, format: ReportFormat): string {
     case "json":
       return JSON.stringify(result, null, 2);
     case "markdown":
-    case "github":
       return formatMarkdown(result);
+    case "github":
+      return formatGithub(result);
     case "terminal":
       return formatTerminal(result);
   }
@@ -95,4 +96,77 @@ export function formatMarkdown(result: ScanResult): string {
   }
 
   return lines.join("\n");
+}
+
+export function formatGithub(result: ScanResult): string {
+  const { summary } = result;
+  const lines = [
+    "## next-secure-check",
+    "",
+    `**Status:** ${githubStatus(summary.high, summary.totalFindings)}`,
+    "",
+    "| Metric | Value |",
+    "| --- | --- |",
+    `| Project | ${escapeTableCell(result.project.name ?? "unknown")} |`,
+    `| Framework | ${escapeTableCell(result.project.framework)} |`,
+    `| Score | ${summary.score}/100 |`,
+    `| Risk level | ${escapeTableCell(summary.riskLevel)} |`,
+    `| Findings | ${summary.totalFindings} (HIGH ${summary.high}, MEDIUM ${summary.medium}, LOW ${summary.low}, INFO ${summary.info}) |`
+  ];
+
+  if (result.findings.length === 0) {
+    return [...lines, "", "No findings detected."].join("\n");
+  }
+
+  lines.push("", "### Findings", "");
+  lines.push("| Severity | Rule | Title | Location | Confidence |");
+  lines.push("| --- | --- | --- | --- | --- |");
+
+  for (const severity of SEVERITY_ORDER) {
+    const findings = result.findings.filter((finding) => finding.severity === severity);
+    for (const finding of findings) {
+      lines.push(
+        `| ${finding.severity} | \`${escapeBackticks(finding.ruleId)}\` | ${escapeTableCell(finding.title)} | \`${escapeBackticks(formatLocation(finding))}\` | ${finding.confidence} |`
+      );
+    }
+  }
+
+  lines.push("", "<details>");
+  lines.push("<summary>Recommendations</summary>");
+  lines.push("");
+
+  for (const severity of SEVERITY_ORDER) {
+    const findings = result.findings.filter((finding) => finding.severity === severity);
+    for (const finding of findings) {
+      lines.push(`- **${finding.severity}** \`${escapeBackticks(finding.ruleId)}\` at \`${escapeBackticks(formatLocation(finding))}\`: ${finding.recommendation}`);
+    }
+  }
+
+  lines.push("", "</details>");
+
+  return lines.join("\n");
+}
+
+function githubStatus(high: number, totalFindings: number): string {
+  if (high > 0) {
+    return "Action required";
+  }
+
+  if (totalFindings > 0) {
+    return "Review recommended";
+  }
+
+  return "No findings";
+}
+
+function formatLocation(finding: ScanResult["findings"][number]): string {
+  return `${finding.filePath}${finding.line ? `:${finding.line}` : ""}`;
+}
+
+function escapeBackticks(value: string): string {
+  return value.replaceAll("`", "'");
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\r?\n/g, " ").replaceAll("|", "\\|");
 }


### PR DESCRIPTION
## Summary

- Adds a dedicated `github` reporter format instead of reusing the generic Markdown report.
- Renders a compact GitHub-friendly summary with metric and findings tables.
- Adds recommendations inside a collapsible details block for PR comments or Actions step summaries.
- Adds reporter tests covering the new format and `formatReport(result, "github")` routing.

## Verification

- `pnpm test` -> 40 tests passed
- `pnpm typecheck` -> passed
- `pnpm build` -> passed
- `node packages/cli/dist/index.js scan examples/vulnerable-next-app --format github` -> produced heading, metric table, findings table, recommendations block, and HIGH findings

## Scope

This PR intentionally only touches `packages/reporter`. It does not add the GitHub Actions workflow yet; that is the next Phase 2 step.