### PR TITLE
Add GitHub Actions security check workflow

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -1,0 +1,45 @@
+name: Security Check
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  next-secure-check:
+    name: next-secure-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build scanner
+        run: pnpm build
+
+      - name: Run security check
+        shell: bash
+        run: |
+          set +e
+          # The repository contains an intentionally vulnerable example app.
+          # This workflow scans the secure example so the workflow itself stays green.
+          node packages/cli/dist/index.js scan examples/secure-next-app --format github --fail-on high | tee next-secure-check-report.md
+          status=${PIPESTATUS[0]}
+          cat next-secure-check-report.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ AI helps with speed, structure, and iteration. Technical ownership, product dire
 npx next-secure-check scan .
 npx next-secure-check scan . --format json
 npx next-secure-check scan . --format markdown --output report.md
+npx next-secure-check scan . --format github
 npx next-secure-check scan . --fail-on high
 npx next-secure-check scan . --category secrets,auth,xss
 ```
@@ -60,10 +61,52 @@ node packages/cli/dist/index.js scan examples/vulnerable-next-app
 node packages/cli/dist/index.js scan examples/vulnerable-next-app --format json
 ```
 
+## GitHub Actions
+
+After the package is published, copy this workflow into `.github/workflows/security-check.yml` in your project:
+
+```yaml
+name: Security Check
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  next-secure-check:
+    name: next-secure-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run security check
+        shell: bash
+        run: |
+          set +e
+          npx --yes next-secure-check@latest scan . --format github --fail-on high | tee next-secure-check-report.md
+          status=${PIPESTATUS[0]}
+          cat next-secure-check-report.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+```
+
+This fails the pull request when findings at `HIGH` or above are found. Change `--fail-on` to `medium`, `low`, or `info` if your team wants a stricter gate.
+
+Findings are deterministic pattern matches, not proof of exploitation. Review the `confidence`, `evidence`, and `recommendation` fields before treating a finding as a confirmed vulnerability.
+
 ## Immediate Goal
 
 ```txt
-Phase 1: harden the CLI MVP with stronger rules, docs, and release polish.
+Phase 2: prove the CLI inside GitHub Actions before moving to deeper rules or SaaS work.
 ```
 
 ## Release Gates


### PR DESCRIPTION
## Summary

- Adds a repository GitHub Actions workflow that runs the local scanner on the secure example app and writes the GitHub reporter output to the Actions step summary.
- Documents the copyable user workflow for running `npx next-secure-check@latest scan . --format github --fail-on high` on pull requests.
- Adds README guidance for `--format github`, `--fail-on`, and false-positive review expectations.

## Verification

- `pnpm test` -> 40 tests passed
- `pnpm typecheck` -> passed
- `pnpm build` -> passed
- `node packages/cli/dist/index.js scan examples/secure-next-app --format github --fail-on high` -> exit 0 and rendered GitHub summary output

## Scope

This PR intentionally does not run the live failing vulnerable demo yet. The repository workflow scans `examples/secure-next-app` because `examples/vulnerable-next-app` is intentionally vulnerable and would make every PR fail. The failing demo PR is the next Phase 2 step.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/setrathexx/next-secure-check/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->