### PR TITLE
Demo: prove security check fails on HIGH findings

### DIFF
--- a/examples/secure-next-app/app/api/demo-login/route.ts
+++ b/examples/secure-next-app/app/api/demo-login/route.ts
@@ -1,0 +1,5 @@
+const JWT_SECRET = "secret";
+
+export async function POST() {
+  return Response.json({ token: JWT_SECRET });
+}


### PR DESCRIPTION
## Purpose

This is an intentional validation PR for Phase 2. Do not merge it.

It adds a deliberately weak `JWT_SECRET` to `examples/secure-next-app` so the new GitHub Actions workflow can prove that `next-secure-check` fails a pull request when HIGH findings are present.

## Expected Result

The `Security Check / next-secure-check` workflow should fail because the scanner finds HIGH severity issues.

Local smoke result:

```txt
node packages/cli/dist/index.js scan examples/secure-next-app --format github --fail-on high

demoScanExit=1
HIGH findings detected:
- auth/login-without-rate-limit
- secrets/weak-jwt-secret
```

## Scope

This PR is only a live CI proof. It should be closed after the failing Action is confirmed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/setrathexx/next-secure-check/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->