### PR TITLE
feat: add shared bounded AnalysisFacts (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a root composite GitHub Action wrapper for `next-secure-check@0.4.1` with preset, fail-on, format, exclude, and output inputs.
 - Added a CI smoke step that exercises the local Action against the secure fixture.
 - Added an opt-in terminal-only `--summary` view for concise score, risk, finding-count, severity, confidence, context, and location output.
+- Added shared syntax-only bounded-flow facts for direct sources, command sinks, guards, short aliases, invalidations, function boundaries, and proven evidence paths.
 
 ### Documentation
 - Added the reproducible VHS README demo, simplified SVG wordmark, and v0.5 summary-output validation note.
 - Added the v0.5 baseline/finding-identity inventory and bounded-flow contract decision note for issue #13.
+- Added the shared `AnalysisFacts` foundation validation note for issue #14.
 
 ### Tests
-- Current validation baseline: 323 package tests, 146 web tests, 469 total tests.
+- Current validation baseline: 326 package tests, 146 web tests, 472 total tests.
 
 ## [0.4.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -393,9 +393,9 @@ pnpm test
 The current validation baseline is:
 
 ~~~txt
-packages: 323 tests
+packages: 326 tests
 apps/web: 146 tests
-total: 469 tests
+total: 472 tests
 ~~~
 
 Workspace layout:
@@ -418,6 +418,7 @@ Useful validation references:
 - [concise terminal summary validation](./docs/validation/phase-9-summary-output.md)
 - [v0.5 baseline and bounded-flow contract](./docs/decisions/0002-v0.5-bounded-flow-contract.md)
 - [v0.5 baseline validation inventory](./docs/validation/phase-10-v0.5-baseline.md)
+- [v0.5 shared AnalysisFacts validation](./docs/validation/phase-11-analysis-facts.md)
 
 ## Learning Project and Development Philosophy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Public progress board for `next-secure-check`. It records completed release work
 | Last reviewed | 2026-08-29 |
 | Current release | `v0.4.1` published |
 | Next release focus | `v0.5.0` - explainable bounded analysis |
-| Current next task | v0.5 Phase 1 - Shared `AnalysisFacts` foundation (#14) |
+| Current next task | v0.5 Phase 2 - Raw SQL bounded source-to-sink pilot (#15) |
 | Release blocker | None for the published line; issue #12 is optional demo/media follow-up |
 
 ## Progress Legend
@@ -24,7 +24,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] `v0.4.0` published as the bounded-analysis feature release.
 - [x] `v0.4.1` published as the CLI documentation-only patch.
 - [x] npm package, workspace package metadata, GitHub Actions validation, pack smoke, and release documentation completed.
-- [x] Current validation baseline: 323 package tests, 146 web tests, 469 total tests.
+- [x] Current validation baseline: 326 package tests, 146 web tests, 472 total tests.
 - [x] Repository self-scan with `--preset app`: 100/100, `excellent`, 0 findings.
 - [x] Vulnerable fixture with `--preset strict`: 0/100, `critical`, 26 findings.
 - [x] Secure fixture with `--preset app`: 99/100, `excellent`, 1 LOW finding.
@@ -44,6 +44,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] [v0.5 concise terminal summary validation](./docs/validation/phase-9-summary-output.md)
 - [x] [v0.5 baseline and bounded-flow contract](./docs/decisions/0002-v0.5-bounded-flow-contract.md)
 - [x] [v0.5 baseline validation inventory](./docs/validation/phase-10-v0.5-baseline.md)
+- [x] [v0.5 shared AnalysisFacts validation](./docs/validation/phase-11-analysis-facts.md)
 - [x] [v0.4.1 GitHub release](https://github.com/SetraTheXX/next-secure-check/releases/tag/v0.4.1)
 - [x] [release history](./CHANGELOG.md)
 
@@ -159,7 +160,7 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 ### v0.5 issue map
 
 - [x] [#13 Baseline and bounded-flow contract](https://github.com/SetraTheXX/next-secure-check/issues/13)
-- [ ] [#14 Shared `AnalysisFacts` foundation](https://github.com/SetraTheXX/next-secure-check/issues/14)
+- [x] [#14 Shared `AnalysisFacts` foundation](https://github.com/SetraTheXX/next-secure-check/issues/14)
 - [ ] [#15 Raw SQL bounded source-to-sink pilot](https://github.com/SetraTheXX/next-secure-check/issues/15)
 - [ ] [#16 XSS source and sanitizer refinement](https://github.com/SetraTheXX/next-secure-check/issues/16)
 - [ ] [#17 Auth and middleware intent signals](https://github.com/SetraTheXX/next-secure-check/issues/17)
@@ -206,16 +207,16 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 
 ## v0.5 Phase 1 - Shared bounded-flow foundation (#14)
 
-- [ ] **Phase status:** Planned
+- [x] **Phase status:** Complete; implementation and validation recorded in [phase-11-analysis-facts.md](./docs/validation/phase-11-analysis-facts.md)
 
 **Purpose:** Extend the existing parse-cache and `AnalysisFacts` layer without duplicating rule-specific AST walks.
 
-- [ ] Reuse the existing one-parse-per-source-file lifecycle.
-- [ ] Add source, sink, guard, alias, and evidence facts only where they have rule-specific meaning.
-- [ ] Avoid a universal `sanitized` or `safe` flag; SQL, HTML, and command guards must remain separate.
-- [ ] Add explicit facts for alias creation, reassignment, and function-boundary stop.
-- [ ] Add unit tests for direct expressions, one-to-two aliases, reassignment, mutation, closure, and malformed TS/TSX.
-- [ ] Keep the existing direct pattern matchers as a fallback when no source can be proven.
+- [x] Reuse the existing one-parse-per-source-file lifecycle.
+- [x] Add source, sink, guard, alias, and evidence facts only where they have rule-specific meaning.
+- [x] Avoid a universal `sanitized` or `safe` flag; SQL, HTML, and command guards must remain separate.
+- [x] Add explicit facts for alias creation, reassignment, and function-boundary stop.
+- [x] Add unit tests for direct expressions, one-to-two aliases, reassignment, mutation, closure, and malformed TS/TSX.
+- [x] Keep the existing direct pattern matchers as a fallback when no source can be proven.
 
 **Exit criteria:** The foundation is reusable, deterministic, and produces no behavior change until a rule opts into it.
 
@@ -347,7 +348,7 @@ These are valuable, but should not block the v0.5 bounded-analysis quality work:
 ## Recommended implementation order
 
 1. [x] v0.5 Phase 0 - baseline and analysis contract.
-2. [ ] v0.5 Phase 1 - shared bounded-flow foundation.
+2. [x] v0.5 Phase 1 - shared bounded-flow foundation.
 3. [ ] v0.5 Phase 2 - raw SQL bounded flow pilot.
 4. [ ] v0.5 Phase 6 - regression and performance gate for the SQL pilot.
 5. [ ] v0.5 Phase 3 - XSS source/sanitizer refinement.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -2,13 +2,17 @@
 
 This folder contains manual validation notes for project phases and milestone checks.
 
-Current validation baseline:
+Frozen #13 pre-implementation validation baseline:
 
 ```txt
 packages: 323 tests
 apps/web: 146 tests
 total: 469 tests
 ```
+
+The 323-package-test count above is the frozen #13 pre-implementation
+baseline. The current post-#14 validation count is 326 package tests, 146 web
+tests, and 472 total tests; see [phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
 
 Historical v0.1 baseline:
 
@@ -36,6 +40,10 @@ The v0.5 baseline, finding identity inventory, report compatibility contract,
 and bounded-flow boundaries are documented in
 [phase-10-v0.5-baseline.md](./phase-10-v0.5-baseline.md). The decision record is
 [0002-v0.5-bounded-flow-contract.md](../decisions/0002-v0.5-bounded-flow-contract.md).
+
+The shared `AnalysisFacts` foundation, bounded-flow fact vocabulary, and #14
+validation results are documented in
+[phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
 
 ## Post-release Real-world Smoke Note
 

--- a/docs/validation/phase-11-analysis-facts.md
+++ b/docs/validation/phase-11-analysis-facts.md
@@ -1,0 +1,85 @@
+# Phase 11: Shared AnalysisFacts Foundation
+
+Date: 2026-08-29
+
+Issue: [#14](https://github.com/SetraTheXX/next-secure-check/issues/14)
+
+## Purpose
+
+This phase extends the existing per-source-file `AnalysisFacts` cache with a
+shared, syntax-only bounded-flow vocabulary. It is a foundation for later rule
+work; it does not turn the scanner into a universal taint engine and does not
+change a rule's behavior by itself.
+
+## Implemented facts
+
+`AnalysisFacts.boundedFlow` now exposes deterministic facts collected during the
+existing command-flow traversal:
+
+- direct request-derived sources and their safe labels;
+- recognized command sinks and their sink kind;
+- rule-specific command allowlist guards;
+- one- and two-hop identifier aliases with their bounded depth;
+- reassignment, mutation, and call-escape invalidations;
+- function-like nodes that form analysis boundaries;
+- proven source-to-sink evidence paths and guarded sink nodes.
+
+The existing `commandSourcePaths` and `safeCommandCalls` projections continue to
+use the finalized bounded facts, so existing command findings retain their
+behavior until a later rule explicitly consumes the new fields. SQL, HTML, and
+command safety remain separate concepts; no universal `safe` or `sanitized`
+fact was introduced.
+
+## Boundaries preserved
+
+- Parsing remains syntax-first and uses the existing one-parse-per-source-file
+  cache lifecycle.
+- The flow remains local to a source file and function scope, with at most two
+  identifier alias hops.
+- Reassignment, mutation, callback/call escape, function boundaries, dynamic
+  properties, cross-file flow, call graphs, and type resolution remain outside
+  the supported proof boundary.
+- Direct command sink matching remains available when no bounded source path is
+  proven.
+- Malformed JavaScript, JSX, TypeScript, and TSX input is still handled without
+  throwing.
+- Scanned repository code is read as data only; it is not executed.
+
+## Validation
+
+Focused AST/fact tests cover:
+
+- direct request source plus two aliases;
+- command allowlist guard facts;
+- reassignment and mutation invalidation;
+- callback/call escape and function-boundary facts;
+- malformed `.js`, `.jsx`, `.ts`, and `.tsx` input;
+- cache identity and one-parse-per-source-file behavior.
+
+The fixture summaries remained equal to the #13 baseline:
+
+| Target | Preset | Score | Risk | Findings | HIGH | MEDIUM | LOW | INFO |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| `examples/vulnerable-next-app` | `strict` | `0` | `critical` | `26` | `12` | `11` | `2` | `1` |
+| `examples/secure-next-app` | `app` | `99` | `excellent` | `1` | `0` | `0` | `1` | `0` |
+| repository self-scan | `app` | `100` | `excellent` | `0` | `0` | `0` | `0` | `0` |
+
+Fresh local gates:
+
+```txt
+pnpm build       -> pass
+pnpm typecheck   -> pass
+pnpm lint        -> pass
+pnpm test        -> 326 package tests + 146 web tests = 472 total
+```
+
+The package and web tests both passed, and the baseline fixture scans preserved
+finding IDs, severities, risk summaries, and counts. SARIF/report behavior is
+covered by the existing package regression suite; no report contract or
+fingerprint code was changed in this phase.
+
+## Review note
+
+These facts are review signals, not proof of exploitability. A later rule may
+opt in to the shared vocabulary only after its own source/sink semantics,
+fallback behavior, fixture changes, and report impact are measured.

--- a/packages/rules/src/analysis-facts.ts
+++ b/packages/rules/src/analysis-facts.ts
@@ -1,0 +1,103 @@
+import ts from "typescript";
+
+export type BoundedFlowSourceFact = {
+  readonly node: ts.Node;
+  readonly path: string;
+  readonly scope: ts.Node;
+};
+
+export type BoundedFlowSinkFact = {
+  readonly node: ts.CallExpression;
+  readonly scope: ts.Node;
+  readonly kind?: string;
+};
+
+export type BoundedFlowGuardFact = {
+  readonly node: ts.CallExpression;
+  readonly scope: ts.Node;
+  readonly kind: string;
+  readonly identifier?: string;
+};
+
+export type BoundedFlowAliasFact = {
+  readonly node: ts.VariableDeclaration | ts.BinaryExpression;
+  readonly scope: ts.Node;
+  readonly from: string;
+  readonly to: string;
+  readonly depth: number;
+  readonly path?: string;
+};
+
+export type BoundedFlowInvalidationReason = "reassignment" | "mutation" | "call-escape";
+
+export type BoundedFlowInvalidationFact = {
+  readonly node: ts.Node;
+  readonly scope: ts.Node;
+  readonly identifier: string;
+  readonly reason: BoundedFlowInvalidationReason;
+};
+
+export type BoundedFlowFunctionBoundaryFact = {
+  readonly node: ts.Node;
+};
+
+export type BoundedFlowEvidencePathFact = {
+  readonly sink: ts.CallExpression;
+  readonly path: string;
+};
+
+export type BoundedFlowFacts = {
+  readonly sources: readonly BoundedFlowSourceFact[];
+  readonly sinks: readonly BoundedFlowSinkFact[];
+  readonly guards: readonly BoundedFlowGuardFact[];
+  readonly aliases: readonly BoundedFlowAliasFact[];
+  readonly invalidations: readonly BoundedFlowInvalidationFact[];
+  readonly functionBoundaries: readonly BoundedFlowFunctionBoundaryFact[];
+  readonly evidencePaths: ReadonlyMap<ts.CallExpression, string>;
+  readonly guardedSinks: ReadonlySet<ts.CallExpression>;
+};
+
+export type BoundedFlowFactsBuilder = {
+  readonly sourceFacts: Map<ts.Node, BoundedFlowSourceFact>;
+  readonly sinkFacts: Map<ts.CallExpression, BoundedFlowSinkFact>;
+  readonly guardFacts: Map<ts.CallExpression, BoundedFlowGuardFact>;
+  readonly aliasFacts: BoundedFlowAliasFact[];
+  readonly invalidationFacts: BoundedFlowInvalidationFact[];
+  readonly functionBoundaryFacts: BoundedFlowFunctionBoundaryFact[];
+  readonly evidencePaths: Map<ts.CallExpression, string>;
+  readonly guardedSinks: Set<ts.CallExpression>;
+};
+
+export function createBoundedFlowFactsBuilder(): BoundedFlowFactsBuilder {
+  return {
+    sourceFacts: new Map(),
+    sinkFacts: new Map(),
+    guardFacts: new Map(),
+    aliasFacts: [],
+    invalidationFacts: [],
+    functionBoundaryFacts: [],
+    evidencePaths: new Map(),
+    guardedSinks: new Set()
+  };
+}
+
+export function finalizeBoundedFlowFacts(builder: BoundedFlowFactsBuilder): BoundedFlowFacts {
+  const invalidations = new Map<string, BoundedFlowInvalidationFact>();
+  for (const invalidation of builder.invalidationFacts) {
+    invalidations.set(
+      `${invalidation.node.pos}:${invalidation.node.end}:${invalidation.identifier}:${invalidation.reason}`,
+      invalidation
+    );
+  }
+
+  return {
+    sources: Object.freeze([...builder.sourceFacts.values()]),
+    sinks: Object.freeze([...builder.sinkFacts.values()]),
+    guards: Object.freeze([...builder.guardFacts.values()]),
+    aliases: Object.freeze([...builder.aliasFacts]),
+    invalidations: Object.freeze([...invalidations.values()]),
+    functionBoundaries: Object.freeze([...builder.functionBoundaryFacts]),
+    evidencePaths: new Map(builder.evidencePaths),
+    guardedSinks: new Set(builder.guardedSinks)
+  };
+}

--- a/packages/rules/src/ast-utils.test.ts
+++ b/packages/rules/src/ast-utils.test.ts
@@ -24,6 +24,73 @@ describe("analysis facts cache", () => {
     resetAnalysisFactsCacheForTests();
   });
 
+  it("exposes shared bounded-flow facts for a direct source and two aliases", () => {
+    const file = sourceFile([
+      'import { exec } from "node:child_process";',
+      "export async function POST(request) {",
+      "  const body = await request.json();",
+      "  const command = body.command;",
+      "  const alias = command;",
+      "  const second = alias;",
+      "  exec(second);",
+      "}"
+    ].join("\n"));
+
+    const facts = getAnalysisFacts(file).boundedFlow;
+
+    expect(facts.sources.map((source) => source.path)).toEqual(["request.json()"]);
+    expect(facts.sinks).toHaveLength(1);
+    expect(facts.aliases.map((alias) => [alias.from, alias.to, alias.depth])).toEqual([
+      ["command", "alias", 1],
+      ["alias", "second", 2]
+    ]);
+    expect([...facts.evidencePaths.values()]).toEqual(["request.json() -> command -> alias -> second"]);
+    expect(facts.guards).toHaveLength(0);
+  });
+
+  it("records guards, invalidations, and function boundaries without widening flow", () => {
+    const file = sourceFile([
+      'import { exec } from "node:child_process";',
+      "export async function POST(request) {",
+      "  const body = await request.json();",
+      "  let reassigned = body.command;",
+      '  reassigned = "git";',
+      "  exec(reassigned);",
+      "  let mutated = body.command;",
+      '  mutated += " --version";',
+      "  exec(mutated);",
+      "  const guarded = body.command;",
+      '  if (!["git"].includes(guarded)) return Response.json({ ok: false });',
+      "  exec(guarded);",
+      "  setTimeout(() => exec(body.command), 0);",
+      "  function invoke(command) { exec(command); }",
+      "  invoke(body.command);",
+      "}"
+    ].join("\n"));
+
+    const facts = getAnalysisFacts(file).boundedFlow;
+
+    expect(facts.evidencePaths.size).toBe(0);
+    expect(facts.guards.map((guard) => [guard.kind, guard.identifier])).toEqual([
+      ["command-allowlist", "guarded"]
+    ]);
+    expect(facts.invalidations.map((invalidation) => invalidation.reason)).toEqual(
+      expect.arrayContaining(["reassignment", "mutation", "call-escape"])
+    );
+    expect(facts.functionBoundaries.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not crash while collecting facts from malformed JS, JSX, TS, or TSX", () => {
+    for (const extension of ["js", "jsx", "ts", "tsx"]) {
+      const file = sourceFile(
+        "export function broken( { const value = request.json();",
+        `app/api/broken.${extension}`
+      );
+
+      expect(() => findCommandExecutionMatches(file)).not.toThrow();
+    }
+  });
+
   it("records one parse miss and a cache hit for repeated access to one source file", () => {
     const file = sourceFile("export async function GET() { return Response.json({ ok: true }); }");
 

--- a/packages/rules/src/ast-utils.ts
+++ b/packages/rules/src/ast-utils.ts
@@ -1,6 +1,7 @@
 import type { Severity, SourceFile } from "@next-secure-check/core";
 import ts from "typescript";
 import { SourceAnalysisCache, type AnalysisCacheStats } from "./analysis-cache.js";
+import type { BoundedFlowFacts } from "./analysis-facts.js";
 import { collectCommandDiscovery } from "./command-discovery.js";
 import { collectCommandFlowFacts, isAnalyzableCommandExecutionCall } from "./command-flow.js";
 import { findPasswordHandlingNodes, hasPasswordHashingCall } from "./password-ast.js";
@@ -29,6 +30,7 @@ export type DangerouslySetInnerHtmlMatch = AstMatch & {
 
 export type AnalysisFacts = {
   sourceFile: ts.SourceFile;
+  boundedFlow: BoundedFlowFacts;
   commandIdentifiers: ReadonlySet<string>;
   childProcessNamespaces: ReadonlySet<string>;
   commandDeclarationNodes: readonly ts.Node[];
@@ -167,6 +169,7 @@ function createAnalysisFacts(sourceFile: ts.SourceFile): AnalysisFacts {
 
   return {
     sourceFile,
+    boundedFlow: commandFlow.boundedFlow,
     commandIdentifiers: commandDiscovery.commandIdentifiers,
     childProcessNamespaces: commandDiscovery.childProcessNamespaces,
     commandDeclarationNodes: commandDiscovery.commandDeclarationNodes,

--- a/packages/rules/src/command-flow.ts
+++ b/packages/rules/src/command-flow.ts
@@ -12,11 +12,19 @@ import {
   isCommandExecutionCall,
   isCommandMutationOperator
 } from "./command-ast.js";
+import {
+  createBoundedFlowFactsBuilder,
+  finalizeBoundedFlowFacts,
+  type BoundedFlowFacts,
+  type BoundedFlowFactsBuilder,
+  type BoundedFlowInvalidationReason
+} from "./analysis-facts.js";
 import { hasCommandAllowlistGuard, isCommandAllowlistMembershipCall } from "./command-guards.js";
 
 export type CommandFlowFacts = {
   sourcePaths: ReadonlyMap<ts.CallExpression, string>;
   safeCommandCalls: ReadonlySet<ts.CallExpression>;
+  boundedFlow: BoundedFlowFacts;
 };
 
 export function isAnalyzableCommandExecutionCall(
@@ -40,9 +48,9 @@ export function collectCommandFlowFacts(
   commandIdentifiers: ReadonlySet<string>,
   childProcessNamespaces: ReadonlySet<string>
 ): CommandFlowFacts {
-  const sourcePaths = new Map<ts.CallExpression, string>();
-  const safeCommandCalls = new Set<ts.CallExpression>();
-  analyzeCommandScope(sourceFile, sourceFile, commandIdentifiers, childProcessNamespaces, sourcePaths, safeCommandCalls);
+  const factsBuilder = createBoundedFlowFactsBuilder();
+  collectFunctionBoundaryFacts(sourceFile, factsBuilder);
+  analyzeCommandScope(sourceFile, sourceFile, commandIdentifiers, childProcessNamespaces, factsBuilder);
 
   visitCommandNodes(sourceFile, (node) => {
     if (!isCommandFunctionLike(node)) {
@@ -51,11 +59,16 @@ export function collectCommandFlowFacts(
 
     const body = commandFunctionBody(node);
     if (body) {
-      analyzeCommandScope(body, body, commandIdentifiers, childProcessNamespaces, sourcePaths, safeCommandCalls);
+      analyzeCommandScope(body, body, commandIdentifiers, childProcessNamespaces, factsBuilder);
     }
   });
 
-  return { sourcePaths, safeCommandCalls };
+  const boundedFlow = finalizeBoundedFlowFacts(factsBuilder);
+  return {
+    sourcePaths: boundedFlow.evidencePaths,
+    safeCommandCalls: boundedFlow.guardedSinks,
+    boundedFlow
+  };
 }
 
 function isSafeStaticSpawnCall(node: ts.CallExpression): boolean {
@@ -111,6 +124,8 @@ type CommandFlowValue = {
 };
 
 type CommandFlowState = {
+  factsBuilder: BoundedFlowFactsBuilder;
+  scopeRoot: ts.Node;
   declared: Set<string>;
   initialized: Set<string>;
   invalidated: Set<string>;
@@ -131,9 +146,8 @@ function analyzeCommandScope(
   node: ts.Node,
   commandIdentifiers: ReadonlySet<string>,
   childProcessNamespaces: ReadonlySet<string>,
-  sourcePaths: Map<ts.CallExpression, string>,
-  safeCommandCalls: Set<ts.CallExpression>,
-  state: CommandFlowState = createCommandFlowState()
+  factsBuilder: BoundedFlowFactsBuilder,
+  state: CommandFlowState = createCommandFlowState(factsBuilder, scopeRoot)
 ): void {
   if (node !== scopeRoot && isCommandFunctionLike(node)) {
     return;
@@ -148,47 +162,57 @@ function analyzeCommandScope(
   }
 
   if (ts.isPrefixUnaryExpression(node) && isCommandMutationOperator(node.operator)) {
-    invalidateCommandTarget(node.operand, state);
+    invalidateCommandTarget(node.operand, state, "mutation");
   }
 
   if (ts.isPostfixUnaryExpression(node) && isCommandMutationOperator(node.operator)) {
-    invalidateCommandTarget(node.operand, state);
+    invalidateCommandTarget(node.operand, state, "mutation");
   }
 
   if (ts.isCallExpression(node)) {
     if (isAnalyzableCommandExecutionCall(node, commandIdentifiers, childProcessNamespaces)) {
+      state.factsBuilder.sinkFacts.set(node, { node, scope: scopeRoot, kind: commandExecutionName(node.expression) });
       const sourcePath = findCommandSourcePathInArguments(node, state);
       if (sourcePath) {
-        if (isGuardedCommandSink(node, state)) {
-          safeCommandCalls.add(node);
+        const guardIdentifier = guardedCommandIdentifier(node, state);
+        if (guardIdentifier) {
+          state.factsBuilder.guardedSinks.add(node);
+          state.factsBuilder.guardFacts.set(node, {
+            node,
+            scope: scopeRoot,
+            kind: "command-allowlist",
+            identifier: guardIdentifier
+          });
         } else {
-          sourcePaths.set(node, sourcePath);
+          state.factsBuilder.evidencePaths.set(node, sourcePath);
         }
       } else {
-        invalidateTaintedReferences(node, state);
+        invalidateTaintedReferences(node, state, "call-escape");
       }
     } else if (!isCommandAllowlistMembershipCall(node) && !sourcePathForExpression(node, state)) {
-      invalidateTaintedReferences(node, state);
+      invalidateTaintedReferences(node, state, "call-escape");
     }
   }
 
   ts.forEachChild(node, (child) =>
-    analyzeCommandScope(scopeRoot, child, commandIdentifiers, childProcessNamespaces, sourcePaths, safeCommandCalls, state)
+    analyzeCommandScope(scopeRoot, child, commandIdentifiers, childProcessNamespaces, factsBuilder, state)
   );
 }
 
-function isGuardedCommandSink(node: ts.CallExpression, state: CommandFlowState): boolean {
+function guardedCommandIdentifier(node: ts.CallExpression, state: CommandFlowState): string | undefined {
   const [commandArgument] = node.arguments;
   if (!commandArgument) {
-    return false;
+    return undefined;
   }
 
   const normalized = unwrapCommandExpression(commandArgument);
   if (!ts.isIdentifier(normalized) || !sourcePathForExpression(normalized, state)) {
-    return false;
+    return undefined;
   }
 
-  return hasCommandAllowlistGuard(node, normalized.text) && !hasUntrustedSpawnArguments(node, state);
+  return hasCommandAllowlistGuard(node, normalized.text) && !hasUntrustedSpawnArguments(node, state)
+    ? normalized.text
+    : undefined;
 }
 
 function hasUntrustedSpawnArguments(node: ts.CallExpression, state: CommandFlowState): boolean {
@@ -200,8 +224,10 @@ function hasUntrustedSpawnArguments(node: ts.CallExpression, state: CommandFlowS
   return node.arguments.slice(1).some((argument) => Boolean(findCommandSourcePathInExpression(argument, state)));
 }
 
-function createCommandFlowState(): CommandFlowState {
+function createCommandFlowState(factsBuilder: BoundedFlowFactsBuilder, scopeRoot: ts.Node): CommandFlowState {
   return {
+    factsBuilder,
+    scopeRoot,
     declared: new Set<string>(),
     initialized: new Set<string>(),
     invalidated: new Set<string>(),
@@ -217,7 +243,9 @@ function recordCommandDeclaration(node: ts.VariableDeclaration, state: CommandFl
     }
 
     state.initialized.add(node.name.text);
-    trackCommandValue(node.name.text, sourcePathForAssignment(node.initializer, state, node.name.text), state);
+    const value = sourcePathForAssignment(node.initializer, state, node.name.text);
+    recordIdentifierAlias(node, node.name.text, node.initializer, value, state);
+    trackCommandValue(node.name.text, value, state);
     return;
   }
 
@@ -246,23 +274,47 @@ function recordCommandDeclaration(node: ts.VariableDeclaration, state: CommandFl
 function recordCommandAssignment(node: ts.BinaryExpression, state: CommandFlowState): void {
   const target = commandTargetIdentifier(node.left);
   if (!target) {
-    invalidateTaintedReferences(node.left, state);
+    invalidateTaintedReferences(node.left, state, "reassignment");
     return;
   }
 
   if (node.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
-    invalidateCommandTarget(node.left, state);
+    invalidateCommandTarget(node.left, state, "mutation");
     return;
   }
 
   if (state.invalidated.has(target) || state.initialized.has(target)) {
-    invalidateCommandTarget(node.left, state);
+    invalidateCommandTarget(node.left, state, "reassignment");
     return;
   }
 
   state.declared.add(target);
   state.initialized.add(target);
-  trackCommandValue(target, sourcePathForAssignment(node.right, state, target), state);
+  const value = sourcePathForAssignment(node.right, state, target);
+  recordIdentifierAlias(node, target, node.right, value, state);
+  trackCommandValue(target, value, state);
+}
+
+function recordIdentifierAlias(
+  node: ts.VariableDeclaration | ts.BinaryExpression,
+  target: string,
+  expression: ts.Expression,
+  value: CommandFlowValue | undefined,
+  state: CommandFlowState
+): void {
+  const normalized = unwrapCommandExpression(expression);
+  if (!value || value.aliasDepth > COMMAND_ALIAS_LIMIT || !ts.isIdentifier(normalized) || normalized.text === target) {
+    return;
+  }
+
+  state.factsBuilder.aliasFacts.push({
+    node,
+    scope: state.scopeRoot,
+    from: normalized.text,
+    to: target,
+    depth: value.aliasDepth,
+    path: value.path
+  });
 }
 
 function trackCommandValue(name: string, value: CommandFlowValue | undefined, state: CommandFlowState): void {
@@ -354,13 +406,22 @@ function sourcePathForReference(expression: ts.Expression, state: CommandFlowSta
       return undefined;
     }
 
-    return state.tracked.get(normalized.text) ?? (ROUTE_PARAMS_NAMES.test(normalized.text) ? { path: normalized.text, aliasDepth: 0 } : undefined);
+    const tracked = state.tracked.get(normalized.text);
+    if (tracked) {
+      return tracked;
+    }
+
+    if (ROUTE_PARAMS_NAMES.test(normalized.text)) {
+      return recordDirectSource(normalized, { path: normalized.text, aliasDepth: 0 }, state);
+    }
+
+    return undefined;
   }
 
   if (ts.isPropertyAccessExpression(normalized)) {
     const directSource = directCommandPropertySource(normalized);
     if (directSource) {
-      return directSource;
+      return recordDirectSource(normalized, directSource, state);
     }
 
     const base = sourcePathForReference(normalized.expression, state);
@@ -375,7 +436,7 @@ function sourcePathForReference(expression: ts.Expression, state: CommandFlowSta
 
     const directSource = directCommandElementSource(normalized, propertyName);
     if (directSource) {
-      return directSource;
+      return recordDirectSource(normalized, directSource, state);
     }
 
     const base = sourcePathForReference(normalized.expression, state);
@@ -386,12 +447,20 @@ function sourcePathForReference(expression: ts.Expression, state: CommandFlowSta
     const methodName = normalized.expression.name.text;
     const receiver = normalized.expression.expression;
     if ((methodName === "json" || methodName === "formData") && isRequestSourceReceiver(receiver)) {
-      return { path: `${commandExpressionLabel(receiver)}.${methodName}()`, aliasDepth: 0 };
+      return recordDirectSource(
+        normalized,
+        { path: `${commandExpressionLabel(receiver)}.${methodName}()`, aliasDepth: 0 },
+        state
+      );
     }
 
     if (methodName === "get") {
       if (isSearchParamsReceiver(receiver)) {
-        return { path: `${commandExpressionLabel(receiver)}.get()`, aliasDepth: 0 };
+        return recordDirectSource(
+          normalized,
+          { path: `${commandExpressionLabel(receiver)}.get()`, aliasDepth: 0 },
+          state
+        );
       }
 
       const base = sourcePathForReference(receiver, state);
@@ -400,6 +469,15 @@ function sourcePathForReference(expression: ts.Expression, state: CommandFlowSta
   }
 
   return undefined;
+}
+
+function recordDirectSource(node: ts.Node, value: CommandFlowValue, state: CommandFlowState): CommandFlowValue {
+  state.factsBuilder.sourceFacts.set(node, {
+    node,
+    path: value.path,
+    scope: state.scopeRoot
+  });
+  return value;
 }
 
 function directCommandPropertySource(node: ts.PropertyAccessExpression): CommandFlowValue | undefined {
@@ -432,17 +510,22 @@ function commandAlias(value: CommandFlowValue, aliasName: string): CommandFlowVa
   };
 }
 
-function invalidateCommandTarget(node: ts.Node, state: CommandFlowState): void {
+function invalidateCommandTarget(
+  node: ts.Node,
+  state: CommandFlowState,
+  reason: BoundedFlowInvalidationReason
+): void {
   const target = commandTargetIdentifier(node);
   if (target) {
+    recordInvalidation(node, target, reason, state);
     state.tracked.delete(target);
     state.invalidated.add(target);
   }
 
-  invalidateTaintedReferences(node, state);
+  invalidateTaintedReferences(node, state, reason);
 }
 
-function invalidateTaintedReferences(node: ts.Node, state: CommandFlowState): void {
+function invalidateTaintedReferences(node: ts.Node, state: CommandFlowState, reason: BoundedFlowInvalidationReason): void {
   const identifiers = new Set<string>();
   visitCommandNodes(node, (child) => {
     if (!ts.isIdentifier(child) || !state.tracked.has(child.text)) {
@@ -457,9 +540,19 @@ function invalidateTaintedReferences(node: ts.Node, state: CommandFlowState): vo
   });
 
   for (const identifier of identifiers) {
+    recordInvalidation(node, identifier, reason, state);
     state.tracked.delete(identifier);
     state.invalidated.add(identifier);
   }
+}
+
+function recordInvalidation(
+  node: ts.Node,
+  identifier: string,
+  reason: BoundedFlowInvalidationReason,
+  state: CommandFlowState
+): void {
+  state.factsBuilder.invalidationFacts.push({ node, scope: state.scopeRoot, identifier, reason });
 }
 
 function commandTargetIdentifier(node: ts.Node): string | undefined {
@@ -527,6 +620,14 @@ function isCommandFunctionLike(node: ts.Node): node is CommandFunctionLike {
     ts.isMethodDeclaration(node) ||
     ts.isSetAccessorDeclaration(node)
   );
+}
+
+function collectFunctionBoundaryFacts(sourceFile: ts.SourceFile, factsBuilder: BoundedFlowFactsBuilder): void {
+  visitCommandNodes(sourceFile, (node) => {
+    if (isCommandFunctionLike(node)) {
+      factsBuilder.functionBoundaryFacts.push({ node });
+    }
+  });
 }
 
 function commandFunctionBody(node: CommandFunctionLike): ts.Node | undefined {


### PR DESCRIPTION
## Summary
- add a shared syntax-only boundedFlow fact vocabulary to the existing AnalysisFacts cache
- preserve commandSourcePaths, safeCommandCalls, direct matcher fallback, and existing report behavior
- cover direct sources, two-hop aliases, guards, invalidations, callback/function boundaries, malformed JS/JSX/TS/TSX, and document the phase
 
## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test (326 package + 146 web)
- vulnerable/secure/self fixture summaries unchanged from #13
 
Closes #14
