### PR TITLE
feat: add bounded raw SQL flow (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a CI smoke step that exercises the local Action against the secure fixture.
 - Added an opt-in terminal-only `--summary` view for concise score, risk, finding-count, severity, confidence, context, and location output.
 - Added shared syntax-only bounded-flow facts for direct sources, command sinks, guards, short aliases, invalidations, function boundaries, and proven evidence paths.
+- Added the first raw SQL bounded source-to-sink slice for recognized query sinks, SQL-valued local aliases, dynamic string concatenation, and optional source evidence paths.
 
 ### Documentation
 - Added the reproducible VHS README demo, simplified SVG wordmark, and v0.5 summary-output validation note.
 - Added the v0.5 baseline/finding-identity inventory and bounded-flow contract decision note for issue #13.
 - Added the shared `AnalysisFacts` foundation validation note for issue #14.
+- Added the raw SQL bounded-flow validation note for issue #15, including intentional stop conditions and a directional performance sample.
+
+### Fixed
+- Fixed direct route-parameter command sources so they populate the shared bounded-flow source facts as well as the existing evidence path.
 
 ### Tests
-- Current validation baseline: 326 package tests, 146 web tests, 472 total tests.
+- Current validation baseline: 337 package tests, 146 web tests, 483 total tests.
 
 ## [0.4.1] - 2026-08-24
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Public progress board for `next-secure-check`. It records completed release work
 | Last reviewed | 2026-08-29 |
 | Current release | `v0.4.1` published |
 | Next release focus | `v0.5.0` - explainable bounded analysis |
-| Current next task | v0.5 Phase 2 - Raw SQL bounded source-to-sink pilot (#15) |
+| Current next task | v0.5 Phase 6 - Regression and performance release gate (#19) |
 | Release blocker | None for the published line; issue #12 is optional demo/media follow-up |
 
 ## Progress Legend
@@ -24,7 +24,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] `v0.4.0` published as the bounded-analysis feature release.
 - [x] `v0.4.1` published as the CLI documentation-only patch.
 - [x] npm package, workspace package metadata, GitHub Actions validation, pack smoke, and release documentation completed.
-- [x] Current validation baseline: 326 package tests, 146 web tests, 472 total tests.
+- [x] Current validation baseline: 337 package tests, 146 web tests, 483 total tests.
 - [x] Repository self-scan with `--preset app`: 100/100, `excellent`, 0 findings.
 - [x] Vulnerable fixture with `--preset strict`: 0/100, `critical`, 26 findings.
 - [x] Secure fixture with `--preset app`: 99/100, `excellent`, 1 LOW finding.
@@ -45,6 +45,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] [v0.5 baseline and bounded-flow contract](./docs/decisions/0002-v0.5-bounded-flow-contract.md)
 - [x] [v0.5 baseline validation inventory](./docs/validation/phase-10-v0.5-baseline.md)
 - [x] [v0.5 shared AnalysisFacts validation](./docs/validation/phase-11-analysis-facts.md)
+- [x] [v0.5 raw SQL bounded-flow validation](./docs/validation/phase-12-raw-sql-bounded-flow.md)
 - [x] [v0.4.1 GitHub release](https://github.com/SetraTheXX/next-secure-check/releases/tag/v0.4.1)
 - [x] [release history](./CHANGELOG.md)
 
@@ -161,7 +162,7 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 
 - [x] [#13 Baseline and bounded-flow contract](https://github.com/SetraTheXX/next-secure-check/issues/13)
 - [x] [#14 Shared `AnalysisFacts` foundation](https://github.com/SetraTheXX/next-secure-check/issues/14)
-- [ ] [#15 Raw SQL bounded source-to-sink pilot](https://github.com/SetraTheXX/next-secure-check/issues/15)
+- [x] [#15 Raw SQL bounded source-to-sink pilot](https://github.com/SetraTheXX/next-secure-check/issues/15)
 - [ ] [#16 XSS source and sanitizer refinement](https://github.com/SetraTheXX/next-secure-check/issues/16)
 - [ ] [#17 Auth and middleware intent signals](https://github.com/SetraTheXX/next-secure-check/issues/17)
 - [ ] [#18 Evidence and reporter explanations](https://github.com/SetraTheXX/next-secure-check/issues/18)
@@ -224,18 +225,18 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 
 ## v0.5 Phase 2 - Raw SQL bounded flow pilot (#15)
 
-- [ ] **Phase status:** Planned; first implementation target
+- [x] **Phase status:** Complete; implementation and validation recorded in [phase-12-raw-sql-bounded-flow.md](./docs/validation/phase-12-raw-sql-bounded-flow.md)
 
 **Purpose:** Distinguish a value that reaches a recognized SQL sink from a SQL-looking string that never reaches one.
 
-- [ ] Recognize direct request-derived sources: `request.json()`, `request.formData()`, `req.body`, `req.query`, and `searchParams.get(...)`.
-- [ ] Recognize direct sinks: `db.query`, `connection.query`, `connection.execute`, `pool.query`, `client.query`, `$queryRaw`, and `$executeRaw`.
-- [ ] Track direct expressions and a short same-function alias chain into a query sink.
-- [ ] Do not report a plain SQL-like template assigned to a variable when no direct sink is visible.
-- [ ] Do not report clearly parameterized query calls with placeholder parameters.
-- [ ] Stop tracking on reassignment, mutation, function boundary, and cross-file flow.
-- [ ] Preserve app/api severity and context tuning; strict/audit must keep their current behavior.
-- [ ] Add a concise evidence path when a source-to-sink path is proven.
+- [x] Recognize direct request-derived sources: `request.json()`, `request.formData()`, `req.body`, `req.query`, and `searchParams.get(...)`.
+- [x] Recognize direct sinks: `db.query`, `connection.query`, `connection.execute`, `pool.query`, `client.query`, `$queryRaw`, and `$executeRaw`.
+- [x] Track direct expressions and a short same-function alias chain into a query sink.
+- [x] Do not report a plain SQL-like template assigned to a variable when no direct sink is visible.
+- [x] Do not report clearly parameterized query calls with placeholder parameters.
+- [x] Stop tracking on reassignment, mutation, function boundary, and cross-file flow.
+- [x] Preserve app/api severity and context tuning; strict/audit must keep their current behavior.
+- [x] Add a concise evidence path when a source-to-sink path is proven.
 
 **Exit criteria:** The pilot demonstrates measured noise reduction or measured additional true findings, preserves safe parameterized-query fixtures, keeps report formats compatible, and documents intentional false negatives such as variable flow across functions.
 
@@ -349,7 +350,7 @@ These are valuable, but should not block the v0.5 bounded-analysis quality work:
 
 1. [x] v0.5 Phase 0 - baseline and analysis contract.
 2. [x] v0.5 Phase 1 - shared bounded-flow foundation.
-3. [ ] v0.5 Phase 2 - raw SQL bounded flow pilot.
+3. [x] v0.5 Phase 2 - raw SQL bounded flow pilot.
 4. [ ] v0.5 Phase 6 - regression and performance gate for the SQL pilot.
 5. [ ] v0.5 Phase 3 - XSS source/sanitizer refinement.
 6. [ ] v0.5 Phase 4 - auth and middleware intent.

--- a/docs/rules/raw-sql-concat.md
+++ b/docs/rules/raw-sql-concat.md
@@ -1,7 +1,7 @@
 # injection/raw-sql-concat
 
 ## Description
-Detects interpolated SQL passed directly to a recognized query sink.
+Detects interpolated or concatenated SQL that reaches a recognized query sink.
 
 ## Why is this a problem?
 Building SQL queries by directly inserting variables into the query string leads to SQL Injection (SQLi). An attacker can manipulate the input to alter the structure of the SQL query, allowing them to bypass authentication, access, modify, or delete unauthorized data, or even execute administrative operations on the database.
@@ -13,8 +13,30 @@ Building SQL queries by directly inserting variables into the query string leads
 
 ## Context and False Positives
 
-The current rule uses syntax-level AST matching for direct call arguments and tagged-template query sinks such as `db.query(...)`, `connection.execute(...)`, and ``prisma.$queryRaw`...` ``. Plain SQL-like template strings assigned to a variable are intentionally outside the current flow boundary unless they are passed directly to a recognized sink.
+The rule is syntax-first and uses the shared bounded-flow traversal. It recognizes
+the following source labels when the AST makes them visible:
+
+- `request.json()` and `request.formData()`;
+- `req.body` and `req.query`;
+- `searchParams.get(...)`;
+- route-parameter members such as `params.id`.
+
+Recognized query sinks include `query` and `execute` member calls on common
+database clients, plus `$queryRaw` and `$executeRaw` call/tag forms. Direct
+interpolation at a recognized sink remains a review signal even when a source
+path cannot be proven. The bounded path adds an `evidencePath` only when the
+source-to-sink relationship is visible.
+
+The flow follows direct expressions, SQL-valued local variables, and at most two
+same-function identifier aliases. A SQL-looking template assigned to a variable
+is not reported until it reaches a recognized sink. Reassignment, mutation,
+unknown call escape, function boundaries, cross-file flow, dynamic properties,
+and aliases beyond the two-hop limit stop evidence propagation. These are
+intentional under-approximations, not proofs that the value is safe.
 
 The highest-risk pattern is user-controlled input reaching a real query sink such as `db.query`, `connection.execute`, or an unsafe raw SQL API. Parameterized queries with placeholders and a separate values array are not treated as the same interpolation pattern. Treat findings as review signals and confirm whether the SQL string is actually executed.
 
-Variable flow across separate statements, custom query wrappers, and type-aware sink resolution remain limitations. A future version may extend the sink model after benchmark coverage shows that the added reach improves signal without recreating broad string noise.
+Custom query wrappers, type-aware sink resolution, cross-function flow, and
+full SQL parser/semantic analysis remain limitations. The current bounded slice
+does not execute scanned repository code and does not use TypeChecker or a
+project-wide call graph.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -11,8 +11,10 @@ total: 469 tests
 ```
 
 The 323-package-test count above is the frozen #13 pre-implementation
-baseline. The current post-#14 validation count is 326 package tests, 146 web
-tests, and 472 total tests; see [phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
+baseline. The post-#14 validation count was 326 package tests, 146 web tests,
+and 472 total tests; see [phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
+The current #15 raw-SQL pilot count is 337 package tests, 146 web tests, and
+483 total tests; see [phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md).
 
 Historical v0.1 baseline:
 
@@ -44,6 +46,10 @@ and bounded-flow boundaries are documented in
 The shared `AnalysisFacts` foundation, bounded-flow fact vocabulary, and #14
 validation results are documented in
 [phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
+
+The #15 raw-SQL bounded source-to-sink pilot, route-parameter fact fix,
+fixture stability, and directional performance sample are documented in
+[phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md).
 
 ## Post-release Real-world Smoke Note
 

--- a/docs/validation/phase-12-raw-sql-bounded-flow.md
+++ b/docs/validation/phase-12-raw-sql-bounded-flow.md
@@ -1,0 +1,104 @@
+# Phase 12: Raw SQL Bounded Source-to-Sink Pilot
+
+Date: 2026-08-29
+
+Issue: [#15](https://github.com/SetraTheXX/next-secure-check/issues/15)
+
+## Purpose
+
+This phase opts `injection/raw-sql-concat` into the shared syntax-only
+bounded-flow traversal. The goal is to distinguish a SQL-looking value that
+reaches a recognized query sink from a SQL-looking value that is never sent to
+one, while keeping the existing direct sink review signal and public finding
+identity intact.
+
+## Implemented scope
+
+- Direct source labels cover `request.json()`, `request.formData()`,
+  `req.body`, `req.query`, `searchParams.get(...)`, and route-parameter
+  members such as `params.id`.
+- Query sinks cover `.query(...)`, `.execute(...)`, `$queryRaw(...)`, and
+  `$executeRaw(...)` calls, plus the existing `$queryRaw` and `$executeRaw`
+  tagged-template forms.
+- SQL template interpolation and dynamic `+` concatenation are recognized at
+  the sink. SQL-valued local variables may reach the sink through at most two
+  same-function identifier aliases.
+- A bounded `evidencePath` is added only when the source relationship is
+  visible, for example `request.json() -> email -> alias`.
+- Reassignment, mutation, unknown call escape, function boundaries,
+  cross-file flow, dynamic properties, and aliases beyond the two-hop limit
+  stop bounded evidence propagation.
+- Static SQL and placeholder-plus-array parameterized calls remain outside
+  this interpolation/concatenation finding path.
+
+The implementation reuses the existing per-source-file parse/cache lifecycle
+and command-flow traversal through rule-specific callbacks. It does not add a
+TypeChecker path, project graph, call graph, full CFG, unrestricted plugin
+execution, or scanned-repository code execution.
+
+## Bug fixed alongside the pilot
+
+Direct route-parameter use such as `exec(params)` already produced a command
+evidence path but did not add the corresponding source fact to
+`AnalysisFacts.boundedFlow.sources`. A regression test now covers the missing
+fact, and the source branch records the same direct source fact as the other
+recognized sources.
+
+## Regression coverage
+
+Focused rule tests cover:
+
+- direct raw SQL source-to-sink evidence;
+- a SQL-valued variable and two same-function aliases;
+- template interpolation and dynamic string concatenation;
+- all supported request/query/search/route source labels;
+- reassignment, mutation, unknown call escape, function-boundary,
+  cross-function, and over-limit alias stops;
+- SQL templates without a sink;
+- static and placeholder-parameterized queries;
+- query-style `$queryRaw`/`$executeRaw` calls and tagged templates;
+- context tuning behavior for API, app, example, template, and component
+  paths.
+
+The existing direct sink matcher remains the fallback for unproven source
+paths, so the rule continues to provide a review signal without presenting an
+unproven flow as exploit evidence.
+
+## Fixture and compatibility result
+
+The current checked-in vulnerable, secure, and self-scan fixtures retain their
+baseline results:
+
+| Target | Preset | Score | Risk | Findings | HIGH | MEDIUM | LOW | INFO |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| `examples/vulnerable-next-app` | `strict` | `0` | `critical` | `26` | `12` | `11` | `2` | `1` |
+| `examples/secure-next-app` | `app` | `99` | `excellent` | `1` | `0` | `0` | `1` | `0` |
+| repository self-scan | `app` | `100` | `excellent` | `0` | `0` | `0` | `0` | `0` |
+
+Finding IDs, rule IDs, locations, context tuning, CLI flags, and report-format
+contracts remain unchanged. Proven paths continue to use the existing
+optional `evidencePath` field; SARIF keeps it under result properties and
+retains deterministic fingerprints.
+
+## Performance sample
+
+Nine independent runs of the existing 100-file syntax fixture harness were
+used. The p95 uses the nearest-rank method (`n=9`). These are local directional
+measurements, not a universal performance claim:
+
+| State | Median | p95 |
+| --- | ---: | ---: |
+| cold | `50.6 ms` | `54.7 ms` |
+| warm | `51.0 ms` | `56.6 ms` |
+
+The 1,000-file corpus, repeated release benchmark, and acceptance budget are
+reserved for [#19](https://github.com/SetraTheXX/next-secure-check/issues/19).
+
+## Gate status
+
+The focused raw-SQL tests, package tests, web tests, typecheck, lint, build,
+fixture scans, and JSON/SARIF compatibility smoke checks must remain green at
+merge time. Demo GIF/tape changes are intentionally deferred until the full
+v0.5 feature set and release validation are complete.
+
+Findings remain review signals, not proof of exploitability.

--- a/packages/rules/src/analysis-facts.ts
+++ b/packages/rules/src/analysis-facts.ts
@@ -42,7 +42,7 @@ export type BoundedFlowFunctionBoundaryFact = {
 };
 
 export type BoundedFlowEvidencePathFact = {
-  readonly sink: ts.CallExpression;
+  readonly sink: ts.Node;
   readonly path: string;
 };
 
@@ -53,7 +53,7 @@ export type BoundedFlowFacts = {
   readonly aliases: readonly BoundedFlowAliasFact[];
   readonly invalidations: readonly BoundedFlowInvalidationFact[];
   readonly functionBoundaries: readonly BoundedFlowFunctionBoundaryFact[];
-  readonly evidencePaths: ReadonlyMap<ts.CallExpression, string>;
+  readonly evidencePaths: ReadonlyMap<ts.Node, string>;
   readonly guardedSinks: ReadonlySet<ts.CallExpression>;
 };
 
@@ -64,7 +64,7 @@ export type BoundedFlowFactsBuilder = {
   readonly aliasFacts: BoundedFlowAliasFact[];
   readonly invalidationFacts: BoundedFlowInvalidationFact[];
   readonly functionBoundaryFacts: BoundedFlowFunctionBoundaryFact[];
-  readonly evidencePaths: Map<ts.CallExpression, string>;
+  readonly evidencePaths: Map<ts.Node, string>;
   readonly guardedSinks: Set<ts.CallExpression>;
 };
 

--- a/packages/rules/src/ast-utils.test.ts
+++ b/packages/rules/src/ast-utils.test.ts
@@ -48,6 +48,20 @@ describe("analysis facts cache", () => {
     expect(facts.guards).toHaveLength(0);
   });
 
+  it("records a direct route-parameter source in bounded-flow facts", () => {
+    const file = sourceFile([
+      'import { exec } from "node:child_process";',
+      "export function GET(params) {",
+      "  exec(params);",
+      "}"
+    ].join("\n"));
+
+    const facts = getAnalysisFacts(file).boundedFlow;
+
+    expect(facts.sources.map((source) => source.path)).toEqual(["params"]);
+    expect([...facts.evidencePaths.values()]).toEqual(["params"]);
+  });
+
   it("records guards, invalidations, and function boundaries without widening flow", () => {
     const file = sourceFile([
       'import { exec } from "node:child_process";',

--- a/packages/rules/src/ast-utils.ts
+++ b/packages/rules/src/ast-utils.ts
@@ -5,7 +5,7 @@ import type { BoundedFlowFacts } from "./analysis-facts.js";
 import { collectCommandDiscovery } from "./command-discovery.js";
 import { collectCommandFlowFacts, isAnalyzableCommandExecutionCall } from "./command-flow.js";
 import { findPasswordHandlingNodes, hasPasswordHashingCall } from "./password-ast.js";
-import { findRawSqlConcatNodes } from "./sql-ast.js";
+import { createRawSqlFlowCallbacks, findRawSqlConcatNodes } from "./sql-ast.js";
 import {
   ROUTE_HANDLER_NAMES,
   exportedRouteHandlerName,
@@ -92,8 +92,20 @@ export function findCommandExecutionMatches(file: SourceFile): AstMatch[] {
 }
 
 export function findRawSqlConcatMatches(file: SourceFile): AstMatch[] {
-  const { sourceFile } = getAnalysisFacts(file);
-  return dedupeMatches(findRawSqlConcatNodes(sourceFile).map((node) => matchFromNode(file, sourceFile, node)));
+  const { sourceFile, boundedFlow } = getAnalysisFacts(file);
+  const directMatches = findRawSqlConcatNodes(sourceFile);
+  const boundedMatches = boundedFlow.sinks
+    .filter((sink) => sink.kind === "raw-sql")
+    .map((sink) => sink.node);
+  const nodes = [...directMatches, ...boundedMatches];
+
+  return dedupeMatches(
+    nodes.map((node) => {
+      const match = matchFromNode(file, sourceFile, node);
+      const evidencePath = boundedFlow.evidencePaths.get(node);
+      return evidencePath ? { ...match, evidencePath } : match;
+    })
+  );
 }
 
 export function findDangerouslySetInnerHtmlMatches(file: SourceFile): DangerouslySetInnerHtmlMatch[] {
@@ -149,7 +161,8 @@ function createAnalysisFacts(sourceFile: ts.SourceFile): AnalysisFacts {
   const commandFlow = collectCommandFlowFacts(
     sourceFile,
     commandDiscovery.commandIdentifiers,
-    commandDiscovery.childProcessNamespaces
+    commandDiscovery.childProcessNamespaces,
+    createRawSqlFlowCallbacks()
   );
   const routeHandlerNodes: ts.Node[] = [];
   let hasUploadHandling = false;

--- a/packages/rules/src/command-flow.ts
+++ b/packages/rules/src/command-flow.ts
@@ -27,6 +27,26 @@ export type CommandFlowFacts = {
   boundedFlow: BoundedFlowFacts;
 };
 
+export type BoundedFlowContext = {
+  readonly scopeRoot: ts.Node;
+  readonly findSourcePathInExpression: (node: ts.Node) => string | undefined;
+  readonly findSourcePathInArguments: (node: ts.CallExpression) => string | undefined;
+  readonly recordSink: (node: ts.CallExpression, kind?: string) => void;
+  readonly recordEvidencePath: (node: ts.Node, path: string) => void;
+};
+
+export type BoundedFlowCallbacks = {
+  readonly onVariableDeclaration?: (node: ts.VariableDeclaration, context: BoundedFlowContext) => void;
+  readonly onAssignment?: (node: ts.BinaryExpression, context: BoundedFlowContext) => void;
+  readonly onCall?: (node: ts.CallExpression, context: BoundedFlowContext) => void;
+  readonly onTaggedTemplate?: (node: ts.TaggedTemplateExpression, context: BoundedFlowContext) => void;
+  readonly onInvalidation?: (
+    identifier: string,
+    reason: BoundedFlowInvalidationReason,
+    context: BoundedFlowContext
+  ) => void;
+};
+
 export function isAnalyzableCommandExecutionCall(
   node: ts.CallExpression,
   commandIdentifiers: ReadonlySet<string>,
@@ -46,11 +66,12 @@ export function collectCommandSourcePaths(
 export function collectCommandFlowFacts(
   sourceFile: ts.SourceFile,
   commandIdentifiers: ReadonlySet<string>,
-  childProcessNamespaces: ReadonlySet<string>
+  childProcessNamespaces: ReadonlySet<string>,
+  callbacks: BoundedFlowCallbacks = {}
 ): CommandFlowFacts {
   const factsBuilder = createBoundedFlowFactsBuilder();
   collectFunctionBoundaryFacts(sourceFile, factsBuilder);
-  analyzeCommandScope(sourceFile, sourceFile, commandIdentifiers, childProcessNamespaces, factsBuilder);
+  analyzeCommandScope(sourceFile, sourceFile, commandIdentifiers, childProcessNamespaces, factsBuilder, callbacks);
 
   visitCommandNodes(sourceFile, (node) => {
     if (!isCommandFunctionLike(node)) {
@@ -59,13 +80,20 @@ export function collectCommandFlowFacts(
 
     const body = commandFunctionBody(node);
     if (body) {
-      analyzeCommandScope(body, body, commandIdentifiers, childProcessNamespaces, factsBuilder);
+      analyzeCommandScope(body, body, commandIdentifiers, childProcessNamespaces, factsBuilder, callbacks);
     }
   });
 
   const boundedFlow = finalizeBoundedFlowFacts(factsBuilder);
+  const sourcePaths = new Map<ts.CallExpression, string>();
+  for (const [node, path] of boundedFlow.evidencePaths) {
+    if (ts.isCallExpression(node)) {
+      sourcePaths.set(node, path);
+    }
+  }
+
   return {
-    sourcePaths: boundedFlow.evidencePaths,
+    sourcePaths,
     safeCommandCalls: boundedFlow.guardedSinks,
     boundedFlow
   };
@@ -126,6 +154,7 @@ type CommandFlowValue = {
 type CommandFlowState = {
   factsBuilder: BoundedFlowFactsBuilder;
   scopeRoot: ts.Node;
+  callbacks: BoundedFlowCallbacks;
   declared: Set<string>;
   initialized: Set<string>;
   invalidated: Set<string>;
@@ -147,7 +176,8 @@ function analyzeCommandScope(
   commandIdentifiers: ReadonlySet<string>,
   childProcessNamespaces: ReadonlySet<string>,
   factsBuilder: BoundedFlowFactsBuilder,
-  state: CommandFlowState = createCommandFlowState(factsBuilder, scopeRoot)
+  callbacks: BoundedFlowCallbacks,
+  state: CommandFlowState = createCommandFlowState(factsBuilder, scopeRoot, callbacks)
 ): void {
   if (node !== scopeRoot && isCommandFunctionLike(node)) {
     return;
@@ -155,10 +185,12 @@ function analyzeCommandScope(
 
   if (ts.isVariableDeclaration(node)) {
     recordCommandDeclaration(node, state);
+    state.callbacks.onVariableDeclaration?.(node, createBoundedFlowContext(state));
   }
 
   if (ts.isBinaryExpression(node) && isCommandAssignmentOperator(node.operatorToken.kind)) {
     recordCommandAssignment(node, state);
+    state.callbacks.onAssignment?.(node, createBoundedFlowContext(state));
   }
 
   if (ts.isPrefixUnaryExpression(node) && isCommandMutationOperator(node.operator)) {
@@ -169,7 +201,13 @@ function analyzeCommandScope(
     invalidateCommandTarget(node.operand, state, "mutation");
   }
 
+  if (ts.isTaggedTemplateExpression(node)) {
+    state.callbacks.onTaggedTemplate?.(node, createBoundedFlowContext(state));
+  }
+
   if (ts.isCallExpression(node)) {
+    state.callbacks.onCall?.(node, createBoundedFlowContext(state));
+
     if (isAnalyzableCommandExecutionCall(node, commandIdentifiers, childProcessNamespaces)) {
       state.factsBuilder.sinkFacts.set(node, { node, scope: scopeRoot, kind: commandExecutionName(node.expression) });
       const sourcePath = findCommandSourcePathInArguments(node, state);
@@ -195,7 +233,7 @@ function analyzeCommandScope(
   }
 
   ts.forEachChild(node, (child) =>
-    analyzeCommandScope(scopeRoot, child, commandIdentifiers, childProcessNamespaces, factsBuilder, state)
+    analyzeCommandScope(scopeRoot, child, commandIdentifiers, childProcessNamespaces, factsBuilder, callbacks, state)
   );
 }
 
@@ -224,14 +262,33 @@ function hasUntrustedSpawnArguments(node: ts.CallExpression, state: CommandFlowS
   return node.arguments.slice(1).some((argument) => Boolean(findCommandSourcePathInExpression(argument, state)));
 }
 
-function createCommandFlowState(factsBuilder: BoundedFlowFactsBuilder, scopeRoot: ts.Node): CommandFlowState {
+function createCommandFlowState(
+  factsBuilder: BoundedFlowFactsBuilder,
+  scopeRoot: ts.Node,
+  callbacks: BoundedFlowCallbacks
+): CommandFlowState {
   return {
     factsBuilder,
     scopeRoot,
+    callbacks,
     declared: new Set<string>(),
     initialized: new Set<string>(),
     invalidated: new Set<string>(),
     tracked: new Map<string, CommandFlowValue>()
+  };
+}
+
+function createBoundedFlowContext(state: CommandFlowState): BoundedFlowContext {
+  return {
+    scopeRoot: state.scopeRoot,
+    findSourcePathInExpression: (node) => findCommandSourcePathInExpression(node, state),
+    findSourcePathInArguments: (node) => findCommandSourcePathInArguments(node, state),
+    recordSink: (node, kind) => {
+      state.factsBuilder.sinkFacts.set(node, { node, scope: state.scopeRoot, kind });
+    },
+    recordEvidencePath: (node, path) => {
+      state.factsBuilder.evidencePaths.set(node, path);
+    }
   };
 }
 
@@ -373,7 +430,7 @@ function sourcePathForExpression(expression: ts.Expression, state: CommandFlowSt
     }
 
     if (ROUTE_PARAMS_NAMES.test(normalized.text)) {
-      return { path: normalized.text, aliasDepth: 0 };
+      return recordDirectSource(normalized, { path: normalized.text, aliasDepth: 0 }, state);
     }
 
     return undefined;
@@ -553,6 +610,7 @@ function recordInvalidation(
   state: CommandFlowState
 ): void {
   state.factsBuilder.invalidationFacts.push({ node, scope: state.scopeRoot, identifier, reason });
+  state.callbacks.onInvalidation?.(identifier, reason, createBoundedFlowContext(state));
 }
 
 function commandTargetIdentifier(node: ts.Node): string | undefined {

--- a/packages/rules/src/security-rules.test.ts
+++ b/packages/rules/src/security-rules.test.ts
@@ -475,6 +475,18 @@ describe("built-in security rules", () => {
     expect(result.findings.some((finding) => finding.ruleId === "injection/raw-sql-concat")).toBe(false);
   });
 
+  it("flags a raw SQL template after it reaches a query sink through a variable", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "const sql = `SELECT * FROM users WHERE id = ${id}`;",
+        "db.query(sql);"
+      ].join("\n")
+    });
+
+    const findings = result.findings.filter((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(findings).toHaveLength(1);
+  });
+
   it("detects raw SQL interpolation passed to query APIs", async () => {
     const result = await scanFixture({
       "app/api/users/route.ts": [
@@ -485,6 +497,125 @@ describe("built-in security rules", () => {
 
     const findings = result.findings.filter((finding) => finding.ruleId === "injection/raw-sql-concat");
     expect(findings).toHaveLength(2);
+  });
+
+  it("records a bounded request source path for a raw SQL query sink", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "export async function GET(request) {",
+        "  const body = await request.json();",
+        "  const email = body.email;",
+        "  db.query(`SELECT * FROM users WHERE email = ${email}`);",
+        "}"
+      ].join("\n")
+    });
+
+    const finding = result.findings.find((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(finding?.evidencePath).toBe("request.json() -> email");
+  });
+
+  it("tracks a raw SQL query value through two same-function aliases", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "export async function GET(request) {",
+        "  const body = await request.json();",
+        "  const email = body.email;",
+        "  const query = `SELECT * FROM users WHERE email = ${email}`;",
+        "  const alias = query;",
+        "  const second = alias;",
+        "  db.query(second);",
+        "}"
+      ].join("\n")
+    });
+
+    const findings = result.findings.filter((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.evidencePath).toBe("request.json() -> email -> alias -> second");
+  });
+
+  it("detects SQL string concatenation at a recognized query sink", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "export async function GET(request) {",
+        "  const body = await request.json();",
+        "  const id = body.id;",
+        '  db.query("SELECT * FROM users WHERE id = " + id);',
+        "}"
+      ].join("\n")
+    });
+
+    const finding = result.findings.find((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(finding?.evidencePath).toBe("request.json() -> id");
+  });
+
+  it("records the supported request-source paths for raw SQL sinks", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "export async function POST(request, { params }) {",
+        "  const formData = await request.formData();",
+        "  db.query(`SELECT * FROM users WHERE id = ${formData.get('id')}`);",
+        "  db.query(`SELECT * FROM users WHERE id = ${request.body.id}`);",
+        "  db.query(`SELECT * FROM users WHERE id = ${request.query.id}`);",
+        "  db.query(`SELECT * FROM users WHERE id = ${searchParams.get('id')}`);",
+        "  db.query(`SELECT * FROM users WHERE id = ${params.id}`);",
+        "}"
+      ].join("\n")
+    });
+
+    const findings = result.findings.filter((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(findings.map((finding) => finding.evidencePath)).toEqual([
+      "request.formData() -> get()",
+      "request.body -> id",
+      "request.query -> id",
+      "searchParams.get()",
+      "params -> id"
+    ]);
+  });
+
+  it("does not carry a raw SQL query value past reassignment or a function boundary", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "export async function GET(request) {",
+        "  const body = await request.json();",
+        "  const id = body.id;",
+        "  let query = `SELECT * FROM users WHERE id = ${id}`;",
+        '  query = "SELECT * FROM users";',
+        "  db.query(query);",
+        "  function execute(value) { db.query(value); }",
+        "  execute(`SELECT * FROM users WHERE id = ${id}`);",
+        "}"
+      ].join("\n")
+    });
+
+    expect(result.findings.some((candidate) => candidate.ruleId === "injection/raw-sql-concat")).toBe(false);
+  });
+
+  it("does not carry a raw SQL query value through an unknown call escape", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "const query = `SELECT * FROM users WHERE id = ${id}`;",
+        "sendToLogger(query);",
+        "db.query(query);"
+      ].join("\n")
+    });
+
+    expect(result.findings.some((candidate) => candidate.ruleId === "injection/raw-sql-concat")).toBe(false);
+  });
+
+  it("does not infer raw SQL flow beyond two aliases or across a function boundary", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "const query = `SELECT * FROM users WHERE id = ${id}`;",
+        "const first = query;",
+        "const second = first;",
+        "const third = second;",
+        "db.query(third);",
+        "function execute() { db.query(query); }",
+        "execute();"
+      ].join("\n")
+    });
+
+    expect(result.findings.some((candidate) => candidate.ruleId === "injection/raw-sql-concat")).toBe(false);
   });
 
   it("detects raw SQL interpolation passed to common query sink names", async () => {
@@ -537,12 +668,40 @@ describe("built-in security rules", () => {
     expect(findings).toHaveLength(4);
   });
 
+  it("adds a bounded source path to a raw SQL tagged template when it is proven", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "export async function GET(request) {",
+        "  await prisma.$queryRaw`SELECT * FROM users WHERE id = ${request.json()}`;",
+        "}"
+      ].join("\n")
+    });
+
+    const finding = result.findings.find((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(finding?.evidencePath).toBe("request.json()");
+  });
+
+  it("detects raw SQL passed to query-style raw APIs", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "prisma.$queryRaw(`SELECT * FROM users WHERE id = ${id}`);",
+        "prisma.$executeRaw(`DELETE FROM users WHERE id = ${id}`);"
+      ].join("\n")
+    });
+
+    const findings = result.findings.filter((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(findings).toHaveLength(2);
+  });
+
   it("does not flag static or parameterized query calls", async () => {
     const result = await scanFixture({
       "app/api/users/route.ts": [
         'db.query("SELECT * FROM users");',
+        'db.query("SELECT * " + "FROM users");',
         'db.query("SELECT * FROM users WHERE id = ?", [id]);',
-        'db.query("SELECT * FROM users WHERE id = $1", [id]);'
+        'db.query("SELECT * FROM users WHERE id = $1", [id]);',
+        'const query = "SELECT * FROM users WHERE id = $1";',
+        'db.query(query, [id]);'
       ].join("\n")
     });
 

--- a/packages/rules/src/security-rules.ts
+++ b/packages/rules/src/security-rules.ts
@@ -285,6 +285,7 @@ export const rawSqlConcatRule: Rule = {
           line: match.line,
           column: match.column,
           evidence: match.evidence,
+          evidencePath: match.evidencePath,
           description: "SQL built with string interpolation or concatenation can lead to SQL injection.",
           recommendation: "Use parameterized queries, prepared statements, or a safe ORM query builder."
         })

--- a/packages/rules/src/sql-ast.ts
+++ b/packages/rules/src/sql-ast.ts
@@ -1,8 +1,105 @@
 import ts from "typescript";
+import { COMMAND_ALIAS_LIMIT } from "./command-ast.js";
+import type { BoundedFlowCallbacks, BoundedFlowContext } from "./command-flow.js";
 
-const SQL_QUERY_METHOD_NAMES = new Set(["query", "execute"]);
+const SQL_QUERY_METHOD_NAMES = new Set(["query", "execute", "$queryRaw", "$executeRaw"]);
 const SQL_RAW_TAG_NAMES = new Set(["$queryRaw", "$executeRaw"]);
 const SQL_KEYWORD_PATTERN = /\b(SELECT|INSERT|UPDATE|DELETE)\b/i;
+
+type RawSqlFlowValue = {
+  path?: string;
+  aliasDepth: number;
+};
+
+type RawSqlScopeState = {
+  values: Map<string, RawSqlFlowValue>;
+  initialized: Set<string>;
+};
+
+export function createRawSqlFlowCallbacks(): BoundedFlowCallbacks {
+  const states = new WeakMap<ts.Node, RawSqlScopeState>();
+
+  return {
+    onVariableDeclaration: (node, context) => {
+      if (!ts.isIdentifier(node.name)) {
+        return;
+      }
+
+      const state = rawSqlScopeState(states, context);
+      if (!node.initializer) {
+        state.values.delete(node.name.text);
+        state.initialized.delete(node.name.text);
+        return;
+      }
+
+      state.initialized.add(node.name.text);
+      const value = rawSqlValueForExpression(node.initializer, node.name.text, state, context);
+      if (value) {
+        state.values.set(node.name.text, value);
+      } else {
+        state.values.delete(node.name.text);
+      }
+    },
+    onAssignment: (node, context) => {
+      const target = rawSqlTargetIdentifier(node.left);
+      if (!target) {
+        return;
+      }
+
+      const state = rawSqlScopeState(states, context);
+      if (node.operatorToken.kind !== ts.SyntaxKind.EqualsToken || state.initialized.has(target)) {
+        state.values.delete(target);
+        state.initialized.add(target);
+        return;
+      }
+
+      state.initialized.add(target);
+      const value = rawSqlValueForExpression(node.right, target, state, context);
+      if (value) {
+        state.values.set(target, value);
+      } else {
+        state.values.delete(target);
+      }
+    },
+    onCall: (node, context) => {
+      const state = rawSqlScopeState(states, context);
+      if (isSqlQuerySinkCall(node)) {
+        const [firstArgument] = node.arguments;
+        if (firstArgument) {
+          const directExpression = isInterpolatedSqlExpression(firstArgument);
+          const normalized = unwrapRawSqlExpression(firstArgument);
+          const aliasedValue = ts.isIdentifier(normalized) ? state.values.get(normalized.text) : undefined;
+          if (directExpression || aliasedValue) {
+            context.recordSink(node, "raw-sql");
+            const evidencePath = directExpression
+              ? context.findSourcePathInExpression(firstArgument)
+              : aliasedValue?.path;
+            if (evidencePath) {
+              context.recordEvidencePath(node, evidencePath);
+            }
+          }
+        }
+      }
+
+      invalidateRawSqlReferences(node, state);
+    },
+    onTaggedTemplate: (node, context) => {
+      if (!isRawSqlTaggedTemplate(node)) {
+        return;
+      }
+
+      const evidencePath = context.findSourcePathInExpression(node.template);
+      if (evidencePath) {
+        context.recordEvidencePath(node, evidencePath);
+      }
+    },
+    onInvalidation: (identifier, _reason, context) => {
+      const state = rawSqlScopeState(states, context);
+      state.values.delete(identifier);
+      state.initialized.add(identifier);
+    }
+  };
+}
 
 export function findRawSqlConcatNodes(sourceFile: ts.SourceFile): ts.Node[] {
   const matches: ts.Node[] = [];
@@ -10,13 +107,13 @@ export function findRawSqlConcatNodes(sourceFile: ts.SourceFile): ts.Node[] {
   visitSqlNodes(sourceFile, (node) => {
     if (ts.isCallExpression(node) && isSqlQuerySinkCall(node)) {
       const [firstArgument] = node.arguments;
-      if (isInterpolatedSqlTemplate(firstArgument)) {
+      if (isInterpolatedSqlExpression(firstArgument)) {
         matches.push(node);
       }
       return;
     }
 
-    if (ts.isTaggedTemplateExpression(node) && isRawSqlTaggedTemplate(node) && isInterpolatedSqlTemplate(node.template)) {
+    if (ts.isTaggedTemplateExpression(node) && isRawSqlTaggedTemplate(node) && isInterpolatedSqlExpression(node.template)) {
       matches.push(node);
     }
   });
@@ -34,8 +131,122 @@ function isRawSqlTaggedTemplate(node: ts.TaggedTemplateExpression): boolean {
   return ts.isPropertyAccessExpression(tag) && SQL_RAW_TAG_NAMES.has(tag.name.text);
 }
 
-function isInterpolatedSqlTemplate(node: ts.Node | undefined): boolean {
-  return node !== undefined && ts.isTemplateExpression(node) && SQL_KEYWORD_PATTERN.test(node.getText());
+function rawSqlScopeState(states: WeakMap<ts.Node, RawSqlScopeState>, context: BoundedFlowContext): RawSqlScopeState {
+  const existing = states.get(context.scopeRoot);
+  if (existing) {
+    return existing;
+  }
+
+  const created: RawSqlScopeState = { values: new Map<string, RawSqlFlowValue>(), initialized: new Set<string>() };
+  states.set(context.scopeRoot, created);
+  return created;
+}
+
+function rawSqlValueForExpression(
+  expression: ts.Expression,
+  targetName: string,
+  state: RawSqlScopeState,
+  context: BoundedFlowContext
+): RawSqlFlowValue | undefined {
+  if (isInterpolatedSqlExpression(expression)) {
+    return {
+      path: context.findSourcePathInExpression(expression),
+      aliasDepth: 0
+    };
+  }
+
+  const normalized = unwrapRawSqlExpression(expression);
+  if (!ts.isIdentifier(normalized)) {
+    return undefined;
+  }
+
+  const existing = state.values.get(normalized.text);
+  if (!existing || existing.aliasDepth >= COMMAND_ALIAS_LIMIT) {
+    return undefined;
+  }
+
+  return {
+    path: existing.path ? `${existing.path} -> ${targetName}` : undefined,
+    aliasDepth: existing.aliasDepth + 1
+  };
+}
+
+export function isInterpolatedSqlExpression(node: ts.Node | undefined): boolean {
+  const normalized = node && unwrapRawSqlExpression(node as ts.Expression);
+  if (!normalized || !SQL_KEYWORD_PATTERN.test(normalized.getText())) {
+    return false;
+  }
+
+  if (ts.isTemplateExpression(normalized)) {
+    return true;
+  }
+
+  return ts.isBinaryExpression(normalized) && hasStringConcatenation(normalized);
+}
+
+function hasStringConcatenation(node: ts.BinaryExpression): boolean {
+  if (node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    return !isStaticStringExpression(node.left) || !isStaticStringExpression(node.right);
+  }
+
+  return (
+    (ts.isBinaryExpression(node.left) && hasStringConcatenation(node.left)) ||
+    (ts.isBinaryExpression(node.right) && hasStringConcatenation(node.right))
+  );
+}
+
+function isStaticStringExpression(node: ts.Expression): boolean {
+  const normalized = unwrapRawSqlExpression(node);
+  if (ts.isStringLiteralLike(normalized)) {
+    return true;
+  }
+
+  return ts.isBinaryExpression(normalized) &&
+    normalized.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+    isStaticStringExpression(normalized.left) &&
+    isStaticStringExpression(normalized.right);
+}
+
+function rawSqlTargetIdentifier(node: ts.Node): string | undefined {
+  if (ts.isIdentifier(node)) {
+    return node.text;
+  }
+
+  if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+    return rawSqlTargetIdentifier(node.expression);
+  }
+
+  return undefined;
+}
+
+function invalidateRawSqlReferences(node: ts.Node, state: RawSqlScopeState): void {
+  visitSqlNodes(node, (child) => {
+    if (!ts.isIdentifier(child) || !state.values.has(child.text)) {
+      return;
+    }
+
+    if (ts.isPropertyAccessExpression(child.parent) && child.parent.name === child) {
+      return;
+    }
+
+    state.values.delete(child.text);
+    state.initialized.add(child.text);
+  });
+}
+
+function unwrapRawSqlExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAwaitExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+
+  return current;
 }
 
 function visitSqlNodes(node: ts.Node, callback: (node: ts.Node) => void): void {


### PR DESCRIPTION
## Summary
- Fix direct route-parameter source facts so `AnalysisFacts.boundedFlow.sources` matches the existing evidence path.
- Add the first bounded raw-SQL source-to-sink slice on the shared traversal.
- Cover query/execute and raw API call/tag forms, dynamic `+` concatenation, local SQL aliases, evidence paths, and conservative stop conditions.
- Document the scope, fixture stability, and directional performance sample.

## Validation
- `pnpm test` — 337 package + 146 web tests passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm build` — passed.
- Vulnerable fixture: 26 findings; secure fixture: 1 LOW; self-scan: 0 findings.
- JSON/SARIF parse smoke passed; SARIF remained deterministic.

Demo GIF/tape updates are intentionally deferred until the v0.5 feature set is complete.

Closes #15