### PR TITLE
fix: address raw SQL review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed direct route-parameter command sources so they populate the shared bounded-flow source facts as well as the existing evidence path.
+- Fixed raw SQL bounded-flow aliases being dropped after a recognized query sink, so repeated sink uses remain visible.
+- Fixed static raw SQL concatenation with primitive literals being classified as dynamic interpolation.
 
 ### Tests
-- Current validation baseline: 337 package tests, 146 web tests, 483 total tests.
+- Current validation baseline: 339 package tests, 146 web tests, 485 total tests.
 
 ## [0.4.1] - 2026-08-24
 

--- a/docs/validation/phase-12-raw-sql-bounded-flow.md
+++ b/docs/validation/phase-12-raw-sql-bounded-flow.md
@@ -54,6 +54,8 @@ Focused rule tests cover:
 - all supported request/query/search/route source labels;
 - reassignment, mutation, unknown call escape, function-boundary,
   cross-function, and over-limit alias stops;
+- repeated use of a SQL-valued alias across recognized query sinks;
+- static SQL concatenation with fixed primitive literals;
 - SQL templates without a sink;
 - static and placeholder-parameterized queries;
 - query-style `$queryRaw`/`$executeRaw` calls and tagged templates;
@@ -63,6 +65,19 @@ Focused rule tests cover:
 The existing direct sink matcher remains the fallback for unproven source
 paths, so the rule continues to provide a review signal without presenting an
 unproven flow as exploit evidence.
+
+## Post-merge review follow-up
+
+The review of PR #23 found two bounded-flow edge cases that did not change the
+checked-in fixture counts but could affect individual SQL expressions:
+
+- A recognized query sink no longer invalidates the SQL-valued alias it
+  consumes, so a later recognized sink can still report the same tracked value.
+- Fixed primitive literals such as numeric values are treated as static parts of
+  a SQL expression, avoiding a dynamic-concatenation false positive.
+
+Unknown call escapes, reassignment, mutation, and function-boundary invalidation
+remain unchanged.
 
 ## Fixture and compatibility result
 

--- a/packages/rules/src/security-rules.test.ts
+++ b/packages/rules/src/security-rules.test.ts
@@ -487,6 +487,19 @@ describe("built-in security rules", () => {
     expect(findings).toHaveLength(1);
   });
 
+  it("keeps tracking a raw SQL alias after a recognized sink", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": [
+        "const sql = `SELECT * FROM users WHERE id = ${id}`;",
+        "db.query(sql);",
+        "db.execute(sql);"
+      ].join("\n")
+    });
+
+    const findings = result.findings.filter((candidate) => candidate.ruleId === "injection/raw-sql-concat");
+    expect(findings).toHaveLength(2);
+  });
+
   it("detects raw SQL interpolation passed to query APIs", async () => {
     const result = await scanFixture({
       "app/api/users/route.ts": [
@@ -703,6 +716,14 @@ describe("built-in security rules", () => {
         'const query = "SELECT * FROM users WHERE id = $1";',
         'db.query(query, [id]);'
       ].join("\n")
+    });
+
+    expect(result.findings.some((finding) => finding.ruleId === "injection/raw-sql-concat")).toBe(false);
+  });
+
+  it("does not flag static SQL concatenated with a numeric literal", async () => {
+    const result = await scanFixture({
+      "app/api/users/route.ts": 'db.query("SELECT * FROM users LIMIT " + 10);'
     });
 
     expect(result.findings.some((finding) => finding.ruleId === "injection/raw-sql-concat")).toBe(false);

--- a/packages/rules/src/sql-ast.ts
+++ b/packages/rules/src/sql-ast.ts
@@ -81,7 +81,9 @@ export function createRawSqlFlowCallbacks(): BoundedFlowCallbacks {
         }
       }
 
-      invalidateRawSqlReferences(node, state);
+      if (!isSqlQuerySinkCall(node)) {
+        invalidateRawSqlReferences(node, state);
+      }
     },
     onTaggedTemplate: (node, context) => {
       if (!isRawSqlTaggedTemplate(node)) {
@@ -197,7 +199,14 @@ function hasStringConcatenation(node: ts.BinaryExpression): boolean {
 
 function isStaticStringExpression(node: ts.Expression): boolean {
   const normalized = unwrapRawSqlExpression(node);
-  if (ts.isStringLiteralLike(normalized)) {
+  if (
+    ts.isStringLiteralLike(normalized) ||
+    ts.isNumericLiteral(normalized) ||
+    ts.isBigIntLiteral(normalized) ||
+    normalized.kind === ts.SyntaxKind.TrueKeyword ||
+    normalized.kind === ts.SyntaxKind.FalseKeyword ||
+    normalized.kind === ts.SyntaxKind.NullKeyword
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Addresses the two P2 review findings from PR #23: preserves SQL aliases after recognized sinks and treats primitive-literal SQL concatenation as static. Adds regression tests and updates the v0.5 validation notes. Validation: pnpm test, pnpm typecheck, pnpm lint, pnpm build, fixture summaries, and SARIF parsing.