### PR TITLE
feat: add v0.5 regression and performance release gate

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Run v0.5 release gate
+        run: pnpm release:gate
+
       - name: Run security check
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an opt-in terminal-only `--summary` view for concise score, risk, finding-count, severity, confidence, context, and location output.
 - Added shared syntax-only bounded-flow facts for direct sources, command sinks, guards, short aliases, invalidations, function boundaries, and proven evidence paths.
 - Added the first raw SQL bounded source-to-sink slice for recognized query sinks, SQL-valued local aliases, dynamic string concatenation, and optional source evidence paths.
+- Added the v0.5 regression/performance release gate for fixture inventories, deterministic reports, concise summaries, public-output privacy, benchmarks, and CLI pack dry-runs.
 
 ### Documentation
 - Added the reproducible VHS README demo, simplified SVG wordmark, and v0.5 summary-output validation note.
 - Added the v0.5 baseline/finding-identity inventory and bounded-flow contract decision note for issue #13.
 - Added the shared `AnalysisFacts` foundation validation note for issue #14.
 - Added the raw SQL bounded-flow validation note for issue #15, including intentional stop conditions and a directional performance sample.
+- Added the Phase 13 validation note with the repeatable 100/1,000-file cold/warm benchmark protocol and release-gate evidence.
 
 ### Fixed
 - Fixed direct route-parameter command sources so they populate the shared bounded-flow source facts as well as the existing evidence path.
 - Fixed raw SQL bounded-flow aliases being dropped after a recognized query sink, so repeated sink uses remain visible.
 - Fixed static raw SQL concatenation with primitive literals being classified as dynamic interpolation.
+- Fixed secret finding evidence leaking through CLI JSON, terminal, and Markdown reports; public reporter output now uses `[REDACTED]`.
 
 ### Tests
-- Current validation baseline: 339 package tests, 146 web tests, 485 total tests.
+- Current validation baseline: 340 package tests, 146 web tests, 486 total tests.
 
 ## [0.4.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ SARIF 2.1.0 output includes:
 - context and context-reason properties
 - concise messages built from the title, description, and recommendation
 
-Raw secret evidence is not included in SARIF output. Findings are review signals, not proof that an exploit exists; review the confidence, evidence, and recommendation before treating one as a confirmed vulnerability.
+Raw secret evidence is replaced with `[REDACTED]` in JSON, terminal, and Markdown output and is not embedded in SARIF; GitHub output also omits evidence details. Findings are review signals, not proof that an exploit exists; review the confidence, evidence, and recommendation before treating one as a confirmed vulnerability.
 
 ## Reproducible Demo
 
@@ -234,6 +234,16 @@ Expected fixture summaries:
 | repository self-scan with `app` | `100/100`, `excellent`, 0 findings |
 
 These are regression-fixture expectations, not universal accuracy or risk guarantees.
+
+Run the complete local v0.5 regression and performance gate after building:
+
+~~~bash
+pnpm release:gate
+~~~
+
+The gate checks fixture inventories, deterministic JSON/SARIF output, concise
+summary length, public-output privacy, CLI packaging, and disposable 100/1,000
+file benchmark corpora. See the [Phase 13 validation note](./docs/validation/phase-13-v05-release-gate.md) for the protocol and local measurements.
 
 ## GitHub Actions
 
@@ -388,14 +398,15 @@ pnpm build
 pnpm typecheck
 pnpm lint
 pnpm test
+pnpm release:gate
 ~~~
 
 The current validation baseline is:
 
 ~~~txt
-packages: 326 tests
+packages: 340 tests
 apps/web: 146 tests
-total: 472 tests
+total: 486 tests
 ~~~
 
 Workspace layout:
@@ -419,6 +430,7 @@ Useful validation references:
 - [v0.5 baseline and bounded-flow contract](./docs/decisions/0002-v0.5-bounded-flow-contract.md)
 - [v0.5 baseline validation inventory](./docs/validation/phase-10-v0.5-baseline.md)
 - [v0.5 shared AnalysisFacts validation](./docs/validation/phase-11-analysis-facts.md)
+- [v0.5 regression and performance release gate](./docs/validation/phase-13-v05-release-gate.md)
 
 ## Learning Project and Development Philosophy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Public progress board for `next-secure-check`. It records completed release work
 | Last reviewed | 2026-08-29 |
 | Current release | `v0.4.1` published |
 | Next release focus | `v0.5.0` - explainable bounded analysis |
-| Current next task | v0.5 Phase 6 - Regression and performance release gate (#19) |
+| Current next task | v0.5 Phase 3 - XSS source and sanitizer refinement (#16) |
 | Release blocker | None for the published line; issue #12 is optional demo/media follow-up |
 
 ## Progress Legend
@@ -24,7 +24,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] `v0.4.0` published as the bounded-analysis feature release.
 - [x] `v0.4.1` published as the CLI documentation-only patch.
 - [x] npm package, workspace package metadata, GitHub Actions validation, pack smoke, and release documentation completed.
-- [x] Current validation baseline: 337 package tests, 146 web tests, 483 total tests.
+- [x] Current validation baseline: 340 package tests, 146 web tests, 486 total tests.
 - [x] Repository self-scan with `--preset app`: 100/100, `excellent`, 0 findings.
 - [x] Vulnerable fixture with `--preset strict`: 0/100, `critical`, 26 findings.
 - [x] Secure fixture with `--preset app`: 99/100, `excellent`, 1 LOW finding.
@@ -46,6 +46,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] [v0.5 baseline validation inventory](./docs/validation/phase-10-v0.5-baseline.md)
 - [x] [v0.5 shared AnalysisFacts validation](./docs/validation/phase-11-analysis-facts.md)
 - [x] [v0.5 raw SQL bounded-flow validation](./docs/validation/phase-12-raw-sql-bounded-flow.md)
+- [x] [v0.5 regression and performance release gate](./docs/validation/phase-13-v05-release-gate.md)
 - [x] [v0.4.1 GitHub release](https://github.com/SetraTheXX/next-secure-check/releases/tag/v0.4.1)
 - [x] [release history](./CHANGELOG.md)
 
@@ -299,19 +300,19 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 
 ## v0.5 Phase 6 - Regression, benchmark, and release gate (#19)
 
-- [ ] **Phase status:** Planned
+- [x] **Phase status:** Complete; implementation and validation recorded in [phase-13-v05-release-gate.md](./docs/validation/phase-13-v05-release-gate.md)
 
 **Purpose:** Turn the quality claim into repeatable evidence before publishing.
 
-- [ ] Expand the synthetic fixture suite for SQL, XSS, auth, middleware, safe wrappers, aliases, reassignment, and malformed input.
-- [ ] Keep external repositories as opt-in smoke tests, not required CI dependencies.
-- [ ] Add or document a benchmark command for small fixtures and a medium monorepo corpus.
-- [ ] Record cold/warm median and p95 measurements with environment details.
-- [ ] Compare before/after findings by rule, context, severity, confidence, and reviewed FP/FN outcome.
-- [ ] Run build, typecheck, lint, package/web tests, CLI smoke, JSON/SARIF parse, and pack dry-run.
-- [ ] Include concise-summary CLI smoke, determinism, line-count, and public-output privacy checks in the release gate.
-- [ ] Require a release note when fixture counts change intentionally.
-- [ ] Update README, CHANGELOG, validation notes, and GitHub release notes.
+- [x] Expand and freeze the synthetic/regression fixture coverage for SQL, XSS, auth, middleware, safe wrappers, aliases, reassignment, and malformed input.
+- [x] Keep external repositories as opt-in smoke tests, not required CI dependencies.
+- [x] Add and document a benchmark command for small fixtures and a medium monorepo corpus.
+- [x] Record cold/warm median and p95 measurements with environment details.
+- [x] Compare fixture results by rule, context, severity, confidence, and reviewed signal inventory.
+- [x] Run build, typecheck, lint, package/web tests, CLI smoke, JSON/SARIF parse, and pack dry-run.
+- [x] Include concise-summary CLI smoke, determinism, line-count, and public-output privacy checks in the release gate.
+- [x] Require a release note when fixture counts change intentionally.
+- [x] Update README, CHANGELOG, and validation notes; GitHub release-page notes remain part of the v0.5 publication in #20.
 
 **Exit criteria:** No critical regression, deterministic outputs, reviewed fixture changes, compatible reports, and performance within the documented budget.
 

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -13,8 +13,11 @@ total: 469 tests
 The 323-package-test count above is the frozen #13 pre-implementation
 baseline. The post-#14 validation count was 326 package tests, 146 web tests,
 and 472 total tests; see [phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
-The current #15 raw-SQL pilot count is 337 package tests, 146 web tests, and
-483 total tests; see [phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md).
+The #15 raw-SQL pilot recorded 337 package tests, 146 web tests, and 483 total
+tests; subsequent review hardening and the #19 reporter gate bring the current
+count to 340 package tests, 146 web tests, and 486 total tests. See
+[phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md) and
+[phase-13-v05-release-gate.md](./phase-13-v05-release-gate.md).
 
 Historical v0.1 baseline:
 
@@ -50,6 +53,10 @@ validation results are documented in
 The #15 raw-SQL bounded source-to-sink pilot, route-parameter fact fix,
 fixture stability, and directional performance sample are documented in
 [phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md).
+
+The #19 regression, benchmark, deterministic-output, public-privacy, and pack
+release gate are documented in
+[phase-13-v05-release-gate.md](./phase-13-v05-release-gate.md).
 
 ## Post-release Real-world Smoke Note
 

--- a/docs/validation/phase-13-v05-release-gate.md
+++ b/docs/validation/phase-13-v05-release-gate.md
@@ -1,0 +1,119 @@
+# Phase 13: v0.5 Regression, Benchmark, and Release Gate
+
+Date: 2026-08-29
+
+Issue: [#19](https://github.com/SetraTheXX/next-secure-check/issues/19)
+
+## Purpose
+
+This note records the repeatable quality gate for the v0.5 bounded-analysis
+line. It protects the checked-in vulnerable, secure, and self-scan behavior;
+keeps public reports deterministic and private; and records a small and medium
+synthetic-corpus performance envelope.
+
+The gate reads project files as scanner input. It does not execute code from a
+scanned project, clone an external repository, or require a network service.
+
+## Commands
+
+After the workspace has been built, the focused gate is:
+
+```bash
+pnpm release:gate
+```
+
+The complete local release validation sequence is:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm release:gate
+```
+
+CI runs the same gate after build, typecheck, lint, and package/web tests. The
+implementation is [`scripts/v05-release-gate.mjs`](../../scripts/v05-release-gate.mjs).
+
+## Frozen fixture and finding inventory
+
+The gate checks the score, risk level, severity totals, and a deterministic
+inventory keyed by `ruleId`, `context`, `severity`, and `confidence`:
+
+| Target | Preset | Score | Risk | Findings | Inventory status |
+| --- | --- | ---: | --- | ---: | --- |
+| `examples/vulnerable-next-app` | `strict` | `0/100` | `critical` | 26 | unchanged: 19 inventory keys |
+| `examples/secure-next-app` | `app` | `99/100` | `excellent` | 1 LOW | unchanged: 1 inventory key |
+| repository self-scan | `app` | `100/100` | `excellent` | 0 | unchanged: empty |
+
+An intentional fixture change must update the gate inventory, this validation
+note, and the changelog with the reviewed reason. A changed count is not
+silently accepted as a passing release result.
+
+The surrounding regression suite covers the existing bounded command matrix,
+raw SQL sources/sinks and aliases, reassignment and function-boundary stops,
+parameterized SQL, XSS static/sanitized/user-controlled cases, auth and
+middleware intent, and malformed configuration fallback. The earlier command
+flow validation records five confirmed static-spawn noise reductions; these
+are signal-quality evidence, not universal accuracy claims.
+
+## Output contracts
+
+The gate verifies:
+
+- `scan --help` documents `--summary`.
+- JSON plus `--summary` is rejected instead of mixing machine and human output.
+- Each fixture summary stays at or below 14 output lines.
+- Repeated JSON reports match after removing only volatile `scannedAt` and
+  `durationMs` metadata.
+- SARIF remains version `2.1.0`, with 26 vulnerable-fixture results, 19 rule
+  identities, and a partial fingerprint on every result; repeated SARIF is
+  deterministic after JSON parsing.
+- Absolute local paths, credential-shaped tokens, and the privacy-fixture
+  marker do not appear in public JSON, Markdown, GitHub, or SARIF output.
+- Secret finding evidence is `[REDACTED]` in JSON, terminal, and Markdown
+  output; SARIF does not embed evidence. Non-secret evidence remains available
+  in detailed reports.
+- `npm pack --dry-run` succeeds for the CLI package.
+
+## Benchmark protocol and local result
+
+The gate creates disposable source-only corpora with 100 and 1,000 TypeScript
+files. It runs nine cold samples in fresh Node processes and nine warm samples
+in one process. Median and p95 use nearest-rank percentile selection. Cold
+scanner time excludes process startup; cold process time includes the fresh
+Node worker. A same-process no-rule scan is recorded as a bounded-analysis
+overhead proxy, not as a historical cross-commit syntax baseline.
+
+Documented budgets and ratio targets:
+
+| Corpus | Cold scanner p95 | Cold process p95 | Warm p95 | Analysis overhead | Warm scaling |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 100 files | <= 2,000 ms | <= 4,000 ms | <= 2,000 ms | <= 20x | — |
+| 1,000 files | <= 8,000 ms | <= 10,000 ms | <= 8,000 ms | <= 20x | <= 20x |
+
+Local result from the validation run:
+
+```txt
+Environment: Node v24.6.0, pnpm 10.20.0, Windows 10 Home Single Language 64-bit, AMD Ryzen 5 5600
+Samples: 9 cold + 9 warm per corpus
+100 files: cold scanner 117.4/123.7 ms, cold process 517.7/553.2 ms, warm 76.6/103.3 ms, overhead 1.12x
+1000 files: cold scanner 841.8/971.0 ms, cold process 1290.0/1409.5 ms, warm 733.1/829.2 ms, overhead 1.10x
+Warm scaling ratio: 9.57x
+```
+
+These are reproducibility measurements for the documented machine and are
+not universal performance guarantees. The external-repository smoke path
+remains opt-in.
+
+## Result
+
+The gate passed locally with no fixture regression, deterministic reports and
+fingerprints, redacted public evidence, valid package dry-run, and benchmark
+values inside the documented budgets. Remaining intentional false-positive
+and false-negative boundaries are the bounded-flow limits already described in
+the v0.5 decision and Phase 12 notes; a full taint engine, cross-file flow,
+call graph, and type-aware default path remain out of scope.
+
+The GitHub release page and final v0.5 package publication remain Phase 7 /
+issue #20 work and are not implied by this local gate result.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:packages": "vitest run --passWithNoTests",
     "test:web": "pnpm -C apps/web test",
     "typecheck": "pnpm -r --if-present typecheck",
+    "release:gate": "node scripts/v05-release-gate.mjs",
     "clean": "pnpm -r --if-present clean"
   },
   "devDependencies": {

--- a/packages/reporter/src/index.test.ts
+++ b/packages/reporter/src/index.test.ts
@@ -84,6 +84,27 @@ describe("formatSummary", () => {
     expect(JSON.parse(formatReport(result, "json")).summary.score).toBe(100);
   });
 
+  it("redacts secret evidence in public report formats without mutating the finding", () => {
+    const result = createScanResultSkeleton("demo-app");
+    const secretEvidence = 'const STRIPE_KEY = "sk_live_demo_secret"';
+    result.findings = [
+      {
+        ...createContextFinding(),
+        ruleId: "secrets/hardcoded-secret",
+        category: "secrets",
+        evidence: secretEvidence
+      }
+    ];
+
+    expect(JSON.parse(formatReport(result, "json")).findings[0].evidence).toBe("[REDACTED]");
+    expect(formatTerminal(result)).toContain("Evidence: [REDACTED]");
+    expect(formatMarkdown(result)).toContain("- Evidence: `[REDACTED]`");
+    expect(formatReport(result, "json")).not.toContain(secretEvidence);
+    expect(formatTerminal(result)).not.toContain(secretEvidence);
+    expect(formatMarkdown(result)).not.toContain(secretEvidence);
+    expect(result.findings[0].evidence).toBe(secretEvidence);
+  });
+
   it("renders markdown reports", () => {
     const result = createScanResultSkeleton("demo-app");
 

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -11,7 +11,7 @@ const SUMMARY_FINDING_LIMIT = 3;
 export function formatReport(result: ScanResult, format: ReportFormat): string {
   switch (format) {
     case "json":
-      return JSON.stringify(result, null, 2);
+      return JSON.stringify(redactScanResult(result), null, 2);
     case "markdown":
       return formatMarkdown(result);
     case "github":
@@ -50,8 +50,9 @@ export function formatTerminal(result: ScanResult): string {
       const location = `${finding.filePath}${finding.line ? `:${finding.line}` : ""}`;
       lines.push(`- ${location}`);
       lines.push(`  ${finding.title} [${finding.ruleId}, confidence: ${finding.confidence}, context: ${formatContext(finding)}]`);
-      if (finding.evidence) {
-        lines.push(`  Evidence: ${finding.evidence}`);
+      const evidence = redactFindingEvidence(finding);
+      if (evidence) {
+        lines.push(`  Evidence: ${evidence}`);
       }
       lines.push(`  Fix: ${finding.recommendation}`);
     }
@@ -124,8 +125,9 @@ export function formatMarkdown(result: ScanResult): string {
       lines.push(`- Rule: \`${finding.ruleId}\``);
       lines.push(`- Confidence: \`${finding.confidence}\``);
       lines.push(`- Context: \`${formatContext(finding)}\``);
-      if (finding.evidence) {
-        lines.push(`- Evidence: \`${finding.evidence.replaceAll("`", "'")}\``);
+      const evidence = redactFindingEvidence(finding);
+      if (evidence) {
+        lines.push(`- Evidence: \`${evidence.replaceAll("`", "'")}\``);
       }
       lines.push(`- Recommendation: ${finding.recommendation}`);
     }
@@ -351,6 +353,27 @@ function sarifPrecision(confidence: ScanResult["findings"][number]["confidence"]
 
 function isSecretFinding(finding: ScanResult["findings"][number]): boolean {
   return finding.category === "secrets" || finding.ruleId.startsWith("secrets/");
+}
+
+const REDACTED_EVIDENCE = "[REDACTED]";
+
+function redactFindingEvidence(finding: ScanResult["findings"][number]): string | undefined {
+  if (!finding.evidence) {
+    return undefined;
+  }
+
+  return isSecretFinding(finding) ? REDACTED_EVIDENCE : finding.evidence;
+}
+
+function redactScanResult(result: ScanResult): ScanResult {
+  return {
+    ...result,
+    findings: result.findings.map((finding) =>
+      finding.evidence && isSecretFinding(finding)
+        ? { ...finding, evidence: REDACTED_EVIDENCE }
+        : { ...finding }
+    )
+  };
 }
 
 function sarifRuleTags(finding: ScanResult["findings"][number]): string[] {

--- a/scripts/v05-release-gate.mjs
+++ b/scripts/v05-release-gate.mjs
@@ -1,0 +1,419 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const cliPath = path.join(repoRoot, "packages", "cli", "dist", "index.js");
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+const FIXTURES = [
+  {
+    name: "vulnerable",
+    target: "examples/vulnerable-next-app",
+    preset: "strict",
+    expected: { score: 0, riskLevel: "critical", totalFindings: 26, high: 12, medium: 11, low: 2, info: 1 },
+  },
+  {
+    name: "secure",
+    target: "examples/secure-next-app",
+    preset: "app",
+    expected: { score: 99, riskLevel: "excellent", totalFindings: 1, high: 0, medium: 0, low: 1, info: 0 },
+  },
+  {
+    name: "self",
+    target: ".",
+    preset: "app",
+    expected: { score: 100, riskLevel: "excellent", totalFindings: 0, high: 0, medium: 0, low: 0, info: 0 },
+  },
+];
+
+const EXPECTED_INVENTORIES = {
+  vulnerable: {
+    "auth/admin-route-without-auth|api-code|HIGH|MEDIUM": 1,
+    "auth/login-without-rate-limit|api-code|HIGH|MEDIUM": 1,
+    "auth/password-without-hashing-library|api-code|MEDIUM|MEDIUM": 1,
+    "auth/register-without-rate-limit|api-code|HIGH|MEDIUM": 1,
+    "config/insecure-cors-wildcard|api-code|MEDIUM|HIGH": 1,
+    "config/next-powered-by-header|unknown|INFO|MEDIUM": 1,
+    "config/production-browser-source-maps|unknown|LOW|HIGH": 1,
+    "headers/missing-security-headers|unknown|LOW|LOW": 1,
+    "injection/command-exec|api-code|HIGH|MEDIUM": 2,
+    "injection/no-eval|api-code|HIGH|HIGH": 1,
+    "injection/no-new-function|api-code|HIGH|HIGH": 1,
+    "injection/raw-sql-concat|api-code|HIGH|MEDIUM": 1,
+    "secrets/hardcoded-secret|api-code|HIGH|HIGH": 1,
+    "secrets/hardcoded-secret|unknown|HIGH|MEDIUM": 1,
+    "secrets/next-public-secret|unknown|HIGH|MEDIUM": 1,
+    "secrets/weak-jwt-secret|api-code|HIGH|HIGH": 1,
+    "upload/missing-file-size-limit|api-code|MEDIUM|MEDIUM": 1,
+    "upload/missing-file-type-validation|api-code|MEDIUM|MEDIUM": 1,
+    "validation/api-route-without-validation|api-code|MEDIUM|MEDIUM": 6,
+    "xss/dangerously-set-inner-html|app-code|MEDIUM|HIGH": 1
+  },
+  secure: {
+    "headers/missing-security-headers|unknown|LOW|LOW": 1
+  },
+  self: {}
+};
+
+const BENCHMARK_SAMPLES = 9;
+const BENCHMARKS = [
+  { name: "small", files: 100, coldScannerP95Ms: 2_000, coldProcessP95Ms: 4_000, warmP95Ms: 2_000 },
+  { name: "medium", files: 1_000, coldScannerP95Ms: 8_000, coldProcessP95Ms: 10_000, warmP95Ms: 8_000 },
+];
+const MAX_SUMMARY_LINES = 14;
+const MAX_WARM_SCALING_RATIO = 20;
+const MAX_ANALYSIS_OVERHEAD_RATIO = 20;
+const temporaryDirectories = [];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    fail(message);
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    ...options,
+  });
+
+  if (result.error) {
+    fail(`Command could not start: ${command} ${args.join(" ")} (${result.error.message})`);
+  }
+
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runNode(args, options = {}) {
+  return runCommand(process.execPath, args, options);
+}
+
+function runCli(target, options = []) {
+  return runNode([cliPath, "scan", target, ...options]);
+}
+
+function requireSuccess(result, label) {
+  assert(result.status === 0, `${label} failed with exit code ${result.status}`);
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    fail(`${label} did not produce valid JSON`);
+  }
+}
+
+function withoutVolatileMetadata(report) {
+  const copy = JSON.parse(JSON.stringify(report));
+  if (copy.metadata) {
+    delete copy.metadata.scannedAt;
+    delete copy.metadata.durationMs;
+  }
+  return copy;
+}
+
+function stableJson(value) {
+  return JSON.stringify(value);
+}
+
+function percentile(values, quantile) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * quantile) - 1));
+  return sorted[index];
+}
+
+function statistics(values) {
+  return {
+    median: percentile(values, 0.5),
+    p95: percentile(values, 0.95),
+  };
+}
+
+function roundMilliseconds(value) {
+  return Number(value.toFixed(1));
+}
+
+const WINDOWS_ABSOLUTE_PATH = /(?:^|[^A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\[A-Za-z0-9])/;
+const POSIX_ABSOLUTE_PATH = /\/(?:Users|home|runner|tmp|workspace)\//;
+const CREDENTIAL_TOKEN = /\b(?:AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk_(?:live|test)_[A-Za-z0-9_-]{16,})\b/;
+
+function assertPublicOutput(text, label, privateMarker = "") {
+  assert(!WINDOWS_ABSOLUTE_PATH.test(text), `${label} leaked an absolute Windows path`);
+  assert(!POSIX_ABSOLUTE_PATH.test(text), `${label} leaked an absolute POSIX path`);
+  assert(!CREDENTIAL_TOKEN.test(text), `${label} leaked a credential-shaped token`);
+  if (privateMarker) {
+    assert(!text.includes(privateMarker), `${label} leaked the privacy fixture marker`);
+  }
+}
+
+function summaryLineCount(text) {
+  const trimmed = text.trimEnd();
+  return trimmed ? trimmed.split(/\r?\n/).length : 0;
+}
+
+function assertExpectedSummary(summary, expected, label) {
+  for (const key of Object.keys(expected)) {
+    assert(summary?.[key] === expected[key], `${label} changed ${key}: expected ${expected[key]}, received ${summary?.[key]}`);
+  }
+}
+
+function findingInventory(findings) {
+  const inventory = new Map();
+  for (const finding of findings) {
+    const key = [finding.ruleId, finding.context ?? "unknown", finding.severity, finding.confidence].join("|");
+    inventory.set(key, (inventory.get(key) ?? 0) + 1);
+  }
+  return Object.fromEntries([...inventory.entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+async function makeTemporaryDirectory(prefix) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function checkFixtureContracts() {
+  for (const fixture of FIXTURES) {
+    const jsonOptions = ["--preset", fixture.preset, "--format", "json"];
+    const first = runCli(fixture.target, jsonOptions);
+    const second = runCli(fixture.target, jsonOptions);
+    requireSuccess(first, `${fixture.name} JSON scan`);
+    requireSuccess(second, `${fixture.name} repeated JSON scan`);
+
+    const firstReport = parseJson(first.stdout, `${fixture.name} JSON scan`);
+    const secondReport = parseJson(second.stdout, `${fixture.name} repeated JSON scan`);
+    assertExpectedSummary(firstReport.summary, fixture.expected, `${fixture.name} fixture`);
+    assert(stableJson(findingInventory(firstReport.findings)) === stableJson(EXPECTED_INVENTORIES[fixture.name]), `${fixture.name} finding inventory changed`);
+    assert(stableJson(withoutVolatileMetadata(firstReport)) === stableJson(withoutVolatileMetadata(secondReport)), `${fixture.name} JSON report is not deterministic`);
+    assertPublicOutput(first.stdout, `${fixture.name} JSON`);
+
+    const summary = runCli(fixture.target, ["--preset", fixture.preset, "--summary"]);
+    requireSuccess(summary, `${fixture.name} summary scan`);
+    assert(summaryLineCount(summary.stdout) <= MAX_SUMMARY_LINES, `${fixture.name} summary has ${summaryLineCount(summary.stdout)} lines; maximum is ${MAX_SUMMARY_LINES}`);
+    assertPublicOutput(summary.stdout, `${fixture.name} summary`);
+  }
+
+  const help = runNode([cliPath, "scan", "--help"]);
+  requireSuccess(help, "scan help");
+  assert(help.stdout.includes("--summary"), "scan help does not document --summary");
+
+  const incompatible = runCli("examples/secure-next-app", ["--format", "json", "--summary"]);
+  assert(incompatible.status !== 0, "JSON plus --summary should be rejected");
+}
+
+async function checkSarifContract() {
+  const options = ["--preset", "strict", "--format", "sarif"];
+  const first = runCli("examples/vulnerable-next-app", options);
+  const second = runCli("examples/vulnerable-next-app", options);
+  requireSuccess(first, "vulnerable SARIF scan");
+  requireSuccess(second, "repeated vulnerable SARIF scan");
+
+  const firstReport = parseJson(first.stdout, "vulnerable SARIF scan");
+  const secondReport = parseJson(second.stdout, "repeated vulnerable SARIF scan");
+  const firstRun = firstReport.runs?.[0];
+  const secondRun = secondReport.runs?.[0];
+  const results = firstRun?.results ?? [];
+  assert(firstReport.version === "2.1.0", "SARIF version is not 2.1.0");
+  assert(firstReport.runs?.length === 1 && secondReport.runs?.length === 1, "SARIF must contain exactly one run");
+  assert(results.length === 26, `SARIF result count changed: expected 26, received ${results.length}`);
+  assert(new Set(results.map((result) => result.ruleId)).size === 19, "SARIF rule identity count changed: expected 19");
+  assert(results.every((result) => Object.keys(result.partialFingerprints ?? {}).length > 0), "SARIF result is missing a partial fingerprint");
+  assert(stableJson(firstReport) === stableJson(secondReport), "SARIF report is not deterministic");
+  assertPublicOutput(first.stdout, "vulnerable SARIF");
+  assert(secondRun?.results?.length === results.length, "repeated SARIF result count changed");
+}
+
+async function checkPrivacyContract() {
+  const directory = await makeTemporaryDirectory("next-secure-check-v05-privacy-");
+  const marker = "gate-sensitive-marker-0123456789";
+  const configDirectory = path.join(directory, "config");
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(path.join(directory, "package.json"), JSON.stringify({ name: "privacy-fixture", dependencies: { next: "16.3.2" } }));
+  await writeFile(path.join(configDirectory, "secrets.ts"), `export const STRIPE_KEY = "sk_live_${marker}";\n`);
+
+  const target = path.relative(repoRoot, directory);
+  for (const format of ["json", "markdown", "github", "sarif"]) {
+    const result = runCli(target, ["--preset", "strict", "--format", format]);
+    requireSuccess(result, `privacy ${format} scan`);
+    assertPublicOutput(result.stdout, `privacy ${format}`, marker);
+    if (format === "json") {
+      const report = parseJson(result.stdout, "privacy JSON scan");
+      assert(report.findings?.length > 0, "privacy fixture did not produce a finding to redact");
+    }
+  }
+}
+
+async function checkPackContract() {
+  const result = runCommand(pnpmCommand, ["-C", "packages/cli", "exec", "npm", "pack", "--dry-run"], {
+    shell: process.platform === "win32"
+  });
+  requireSuccess(result, "CLI npm pack dry-run");
+  assert(result.stdout.includes("next-secure-check"), "CLI npm pack dry-run did not report the package");
+}
+
+function benchmarkFileContents(index) {
+  const variant = index % 4;
+  if (variant === 0) {
+    return `export const value${index} = ${index};\n`;
+  }
+  if (variant === 1) {
+    return `export function read${index}() { return ${index}; }\n`;
+  }
+  if (variant === 2) {
+    return `const values${index} = [${index}, ${index + 1}, ${index + 2}];\nexport { values${index} };\n`;
+  }
+  return `export const label${index} = "fixture-${index}";\n`;
+}
+
+async function makeBenchmarkCorpus(fileCount) {
+  const directory = await makeTemporaryDirectory(`next-secure-check-v05-${fileCount}-`);
+  await Promise.all(
+    Array.from({ length: fileCount }, (_, index) => writeFile(path.join(directory, `fixture-${index}.ts`), benchmarkFileContents(index))),
+  );
+  return directory;
+}
+
+async function loadScanner() {
+  const [core, rules] = await Promise.all([
+    import(pathToFileURL(path.join(repoRoot, "packages", "core", "dist", "index.js")).href),
+    import(pathToFileURL(path.join(repoRoot, "packages", "rules", "dist", "index.js")).href),
+  ]);
+  return { scanProject: core.scanProject, getBuiltInRules: rules.getBuiltInRules };
+}
+
+async function scanInProcess(scanProject, corpus, rules) {
+  const started = performance.now();
+  const result = await scanProject(corpus, { rules });
+  return { elapsedMs: performance.now() - started, findings: result.findings.length };
+}
+
+function scanInFreshProcess(corpus) {
+  const started = performance.now();
+  const result = runNode([scriptPath, "--benchmark-worker", corpus]);
+  const processMs = performance.now() - started;
+  assert(result.status === 0, `cold benchmark worker failed for ${corpus}`);
+  const payload = parseJson(result.stdout, "cold benchmark worker");
+  assert(payload.findings === 0, `benchmark corpus produced ${payload.findings} findings`);
+  return { scannerMs: payload.scannerMs, processMs };
+}
+
+async function runBenchmark(benchmark, scanner) {
+  const corpus = await makeBenchmarkCorpus(benchmark.files);
+  const fullRules = scanner.getBuiltInRules();
+  const coldScanner = [];
+  const coldProcess = [];
+  const warm = [];
+  const baseline = [];
+
+  try {
+    for (let index = 0; index < BENCHMARK_SAMPLES; index += 1) {
+      const cold = scanInFreshProcess(corpus);
+      coldScanner.push(cold.scannerMs);
+      coldProcess.push(cold.processMs);
+    }
+    for (let index = 0; index < BENCHMARK_SAMPLES; index += 1) {
+      const full = await scanInProcess(scanner.scanProject, corpus, fullRules);
+      assert(full.findings === 0, `warm benchmark produced ${full.findings} findings`);
+      warm.push(full.elapsedMs);
+      const noRules = await scanInProcess(scanner.scanProject, corpus, []);
+      assert(noRules.findings === 0, `no-rule benchmark produced ${noRules.findings} findings`);
+      baseline.push(noRules.elapsedMs);
+    }
+  } finally {
+    await rm(corpus, { recursive: true, force: true });
+    const position = temporaryDirectories.indexOf(corpus);
+    if (position >= 0) {
+      temporaryDirectories.splice(position, 1);
+    }
+  }
+
+  const stats = {
+    coldScanner: statistics(coldScanner),
+    coldProcess: statistics(coldProcess),
+    warm: statistics(warm),
+    baseline: statistics(baseline),
+  };
+  assert(stats.coldScanner.p95 <= benchmark.coldScannerP95Ms, `${benchmark.name} cold scanner p95 exceeded ${benchmark.coldScannerP95Ms}ms`);
+  assert(stats.coldProcess.p95 <= benchmark.coldProcessP95Ms, `${benchmark.name} cold process p95 exceeded ${benchmark.coldProcessP95Ms}ms`);
+  assert(stats.warm.p95 <= benchmark.warmP95Ms, `${benchmark.name} warm p95 exceeded ${benchmark.warmP95Ms}ms`);
+  const analysisOverheadRatio = stats.warm.median / Math.max(stats.baseline.median, 5);
+  assert(analysisOverheadRatio <= MAX_ANALYSIS_OVERHEAD_RATIO, `${benchmark.name} analysis overhead ratio ${analysisOverheadRatio.toFixed(2)} exceeded ${MAX_ANALYSIS_OVERHEAD_RATIO}x`);
+
+  return { ...benchmark, stats, analysisOverheadRatio };
+}
+
+async function checkBenchmarks() {
+  const scanner = await loadScanner();
+  const results = [];
+  for (const benchmark of BENCHMARKS) {
+    results.push(await runBenchmark(benchmark, scanner));
+  }
+
+  const small = results.find((result) => result.name === "small");
+  const medium = results.find((result) => result.name === "medium");
+  const warmScalingRatio = medium.stats.warm.median / Math.max(small.stats.warm.median, 5);
+  assert(warmScalingRatio <= MAX_WARM_SCALING_RATIO, `warm corpus scaling ratio ${warmScalingRatio.toFixed(2)} exceeded ${MAX_WARM_SCALING_RATIO}x`);
+  return { results, warmScalingRatio };
+}
+
+function printBenchmarkResult(result) {
+  const { stats } = result;
+  console.log(
+    `[v05] ${result.name}: ${result.files} files; cold scanner median/p95 ${roundMilliseconds(stats.coldScanner.median)}/${roundMilliseconds(stats.coldScanner.p95)}ms; ` +
+      `cold process median/p95 ${roundMilliseconds(stats.coldProcess.median)}/${roundMilliseconds(stats.coldProcess.p95)}ms; ` +
+      `warm median/p95 ${roundMilliseconds(stats.warm.median)}/${roundMilliseconds(stats.warm.p95)}ms; ` +
+      `analysis overhead ${result.analysisOverheadRatio.toFixed(2)}x`,
+  );
+}
+
+async function runGate() {
+  assert(cliPath && path.isAbsolute(cliPath), "built CLI path is not configured");
+  await checkFixtureContracts();
+  await checkSarifContract();
+  await checkPrivacyContract();
+  await checkPackContract();
+  const benchmark = await checkBenchmarks();
+
+  console.log("[v05] fixture, summary, help, determinism, SARIF, privacy, and pack checks passed");
+  for (const result of benchmark.results) {
+    printBenchmarkResult(result);
+  }
+  console.log(`[v05] warm corpus scaling ratio: ${benchmark.warmScalingRatio.toFixed(2)}x`);
+  console.log("[v05] release gate passed");
+}
+
+async function runBenchmarkWorker(corpus) {
+  assert(corpus, "benchmark worker corpus is missing");
+  const scanner = await loadScanner();
+  const result = await scanInProcess(scanner.scanProject, corpus, scanner.getBuiltInRules());
+  console.log(JSON.stringify({ scannerMs: result.elapsedMs, findings: result.findings }));
+}
+
+try {
+  if (process.argv[2] === "--benchmark-worker") {
+    await runBenchmarkWorker(process.argv[3]);
+  } else {
+    await runGate();
+  }
+} catch (error) {
+  console.error(`[v05] release gate failed: ${error instanceof Error ? error.message : "unknown error"}`);
+  process.exitCode = 1;
+} finally {
+  await Promise.all(temporaryDirectories.map((directory) => rm(directory, { recursive: true, force: true })));
+}


### PR DESCRIPTION
## Summary
- add the local pnpm release:gate regression, determinism, summary, SARIF, privacy, pack, and benchmark gate
- redact secret evidence in CLI JSON, terminal, and Markdown output without mutating findings
- wire the gate into CI and document the Phase 13 validation protocol

## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test (340 package + 146 web = 486)
- pnpm release:gate

Fixture baseline remains vulnerable 0/100 critical (26), secure 99/100 excellent (1 LOW), self-scan 100/100 excellent (0). Final v0.5 publication and GitHub release notes remain issue #20.