### PR TITLE
fix: tighten XSS sanitizer trust boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the first raw SQL bounded source-to-sink slice for recognized query sinks, SQL-valued local aliases, dynamic string concatenation, and optional source evidence paths.
 - Added the v0.5 regression/performance release gate for fixture inventories, deterministic reports, concise summaries, public-output privacy, benchmarks, and CLI pack dry-runs.
 
+### Changed
+- Refined `xss/dangerously-set-inner-html` with a documented sanitizer allowlist and bounded evidence paths for direct request-derived values.
+
 ### Documentation
 - Added the reproducible VHS README demo, simplified SVG wordmark, and v0.5 summary-output validation note.
 - Added the v0.5 baseline/finding-identity inventory and bounded-flow contract decision note for issue #13.
 - Added the shared `AnalysisFacts` foundation validation note for issue #14.
 - Added the raw SQL bounded-flow validation note for issue #15, including intentional stop conditions and a directional performance sample.
 - Added the Phase 13 validation note with the repeatable 100/1,000-file cold/warm benchmark protocol and release-gate evidence.
+- Added the Phase 14 XSS source/sanitizer refinement validation note for issue #16.
 
 ### Fixed
 - Fixed direct route-parameter command sources so they populate the shared bounded-flow source facts as well as the existing evidence path.
 - Fixed raw SQL bounded-flow aliases being dropped after a recognized query sink, so repeated sink uses remain visible.
 - Fixed static raw SQL concatenation with primitive literals being classified as dynamic interpolation.
 - Fixed secret finding evidence leaking through CLI JSON, terminal, and Markdown reports; public reporter output now uses `[REDACTED]`.
+- Fixed unknown XSS sanitizer wrappers being silently treated as safe.
 
 ### Tests
-- Current validation baseline: 340 package tests, 146 web tests, 486 total tests.
+- Current validation baseline: 342 package tests, 146 web tests, 488 total tests.
 
 ## [0.4.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The scanner currently contains 20 built-in rules across secrets, injection, XSS,
 
 See [`docs/rules`](./docs/rules) for the complete rule documentation, examples, and known limitations.
 
+The XSS rule documents its intentionally small sanitizer allowlist and bounded
+request-source evidence in [`dangerously-set-inner-html.md`](./docs/rules/dangerously-set-inner-html.md).
+
 ## CLI Usage
 
 ### Scan and report formats
@@ -404,9 +407,9 @@ pnpm release:gate
 The current validation baseline is:
 
 ~~~txt
-packages: 340 tests
+packages: 342 tests
 apps/web: 146 tests
-total: 486 tests
+total: 488 tests
 ~~~
 
 Workspace layout:
@@ -430,6 +433,7 @@ Useful validation references:
 - [v0.5 baseline and bounded-flow contract](./docs/decisions/0002-v0.5-bounded-flow-contract.md)
 - [v0.5 baseline validation inventory](./docs/validation/phase-10-v0.5-baseline.md)
 - [v0.5 shared AnalysisFacts validation](./docs/validation/phase-11-analysis-facts.md)
+- [v0.5 XSS source and sanitizer refinement](./docs/validation/phase-14-xss-refinement.md)
 - [v0.5 regression and performance release gate](./docs/validation/phase-13-v05-release-gate.md)
 
 ## Learning Project and Development Philosophy

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Public progress board for `next-secure-check`. It records completed release work
 | Last reviewed | 2026-08-29 |
 | Current release | `v0.4.1` published |
 | Next release focus | `v0.5.0` - explainable bounded analysis |
-| Current next task | v0.5 Phase 3 - XSS source and sanitizer refinement (#16) |
+| Current next task | v0.5 Phase 4 - Auth and middleware intent (#17) |
 | Release blocker | None for the published line; issue #12 is optional demo/media follow-up |
 
 ## Progress Legend
@@ -24,7 +24,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] `v0.4.0` published as the bounded-analysis feature release.
 - [x] `v0.4.1` published as the CLI documentation-only patch.
 - [x] npm package, workspace package metadata, GitHub Actions validation, pack smoke, and release documentation completed.
-- [x] Current validation baseline: 340 package tests, 146 web tests, 486 total tests.
+- [x] Current validation baseline: 342 package tests, 146 web tests, 488 total tests.
 - [x] Repository self-scan with `--preset app`: 100/100, `excellent`, 0 findings.
 - [x] Vulnerable fixture with `--preset strict`: 0/100, `critical`, 26 findings.
 - [x] Secure fixture with `--preset app`: 99/100, `excellent`, 1 LOW finding.
@@ -164,10 +164,10 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 - [x] [#13 Baseline and bounded-flow contract](https://github.com/SetraTheXX/next-secure-check/issues/13)
 - [x] [#14 Shared `AnalysisFacts` foundation](https://github.com/SetraTheXX/next-secure-check/issues/14)
 - [x] [#15 Raw SQL bounded source-to-sink pilot](https://github.com/SetraTheXX/next-secure-check/issues/15)
-- [ ] [#16 XSS source and sanitizer refinement](https://github.com/SetraTheXX/next-secure-check/issues/16)
+- [x] [#16 XSS source and sanitizer refinement](https://github.com/SetraTheXX/next-secure-check/issues/16)
 - [ ] [#17 Auth and middleware intent signals](https://github.com/SetraTheXX/next-secure-check/issues/17)
 - [ ] [#18 Evidence and reporter explanations](https://github.com/SetraTheXX/next-secure-check/issues/18)
-- [ ] [#19 Regression and performance release gate](https://github.com/SetraTheXX/next-secure-check/issues/19)
+- [x] [#19 Regression and performance release gate](https://github.com/SetraTheXX/next-secure-check/issues/19)
 - [ ] [#20 v0.5 release and feedback loop](https://github.com/SetraTheXX/next-secure-check/issues/20)
 
 ### v0.5 compatibility rules
@@ -245,18 +245,18 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 
 ## v0.5 Phase 3 - XSS source and sanitizer refinement (#16)
 
-- [ ] **Phase status:** Planned
+- [x] **Phase status:** Complete; implementation and validation recorded in [phase-14-xss-refinement.md](./docs/validation/phase-14-xss-refinement.md)
 
 **Purpose:** Improve the distinction between static HTML, sanitized content, and values that may carry untrusted input into `dangerouslySetInnerHTML`.
 
-- [ ] Keep JSX attribute syntax as the first boundary.
-- [ ] Recognize direct variable and member-expression values as review signals.
-- [ ] Recognize a small, documented sanitizer allowlist such as `DOMPurify.sanitize`, `sanitizeHtml`, and `sanitizeMarkdown`.
-- [ ] Do not assume an unknown custom wrapper is safe.
-- [ ] Keep static literal HTML out of the default finding path.
-- [ ] Add negative fixtures for normal JSX text, unrelated props, static literals, and sanitized values.
-- [ ] Add positive fixtures for request-derived, member-expression, and unsanitized values.
-- [ ] Keep context tuning and strict/audit behavior explicit in tests.
+- [x] Keep JSX attribute syntax as the first boundary.
+- [x] Recognize direct variable and member-expression values as review signals.
+- [x] Recognize a small, documented sanitizer allowlist such as `DOMPurify.sanitize`, `sanitizeHtml`, and `sanitizeMarkdown`.
+- [x] Do not assume an unknown custom wrapper is safe.
+- [x] Keep static literal HTML out of the default finding path.
+- [x] Add negative fixtures for normal JSX text, unrelated props, static literals, and sanitized values.
+- [x] Add positive fixtures for request-derived, member-expression, and unsanitized values.
+- [x] Keep context tuning and strict/audit behavior explicit in tests.
 
 **Exit criteria:** XSS findings explain whether the value is literal, sanitized, or variable-based without claiming source reachability that the analyzer cannot prove.
 
@@ -352,8 +352,8 @@ These are valuable, but should not block the v0.5 bounded-analysis quality work:
 1. [x] v0.5 Phase 0 - baseline and analysis contract.
 2. [x] v0.5 Phase 1 - shared bounded-flow foundation.
 3. [x] v0.5 Phase 2 - raw SQL bounded flow pilot.
-4. [ ] v0.5 Phase 6 - regression and performance gate for the SQL pilot.
-5. [ ] v0.5 Phase 3 - XSS source/sanitizer refinement.
+4. [x] v0.5 Phase 6 - regression and performance gate for the SQL pilot.
+5. [x] v0.5 Phase 3 - XSS source/sanitizer refinement.
 6. [ ] v0.5 Phase 4 - auth and middleware intent.
 7. [ ] v0.5 Phase 5 - evidence/reporting polish.
 8. [ ] v0.5 Phase 7 - release and feedback loop.

--- a/docs/rules/dangerously-set-inner-html.md
+++ b/docs/rules/dangerously-set-inner-html.md
@@ -5,6 +5,15 @@ Detects the usage of the `dangerouslySetInnerHTML` prop in React components.
 
 The current syntax-aware check focuses on JSX attributes whose `__html` value is a variable or member expression, such as `post.content` or `userInput`. Normal JSX text, unrelated props, and static literal HTML are not treated as the same untrusted-content signal. Recognized sanitizer calls are handled conservatively and should still be reviewed in context.
 
+The documented sanitizer allowlist is intentionally small:
+
+- `DOMPurify.sanitize(...)`
+- direct `sanitizeHtml(...)` and `sanitizeMarkdown(...)` calls
+- default imports from `dompurify` or `sanitize-html`, including aliases used with `.sanitize(...)`
+- same-file `const` values derived from one of the cases above
+
+Generic `sanitize(...)`, `sanitizeContent(...)`, `toSafeHtml(...)`, arbitrary `wrapper.sanitize(...)` calls, and sanitizer-looking imports from unknown local modules are not trusted automatically. They remain review signals until the project proves the wrapper's behavior to a human reviewer.
+
 ## Why is this a problem?
 React normally escapes HTML to prevent Cross-Site Scripting (XSS) attacks. However, `dangerouslySetInnerHTML` bypasses this protection and renders raw HTML directly into the DOM. If the HTML content includes untrusted user input, an attacker can inject malicious JavaScript that will execute in the victim's browser.
 
@@ -12,4 +21,4 @@ React normally escapes HTML to prevent Cross-Site Scripting (XSS) attacks. Howev
 1. Avoid using `dangerouslySetInnerHTML` whenever possible. Use standard React components and state to render content.
 2. If you must render raw HTML (e.g., from a Markdown parser or rich text editor), you **must** sanitize the HTML string using a proven library like `DOMPurify` before passing it to `dangerouslySetInnerHTML`.
 
-This refinement reduces metadata and static-literal noise compared with the earlier broad text matcher, while keeping variable/member-expression usage visible. It does not perform source tracking or prove that a value is user-controlled; findings remain review signals rather than proof of exploitation.
+This refinement reduces metadata and static-literal noise compared with the earlier broad text matcher, while keeping variable/member-expression usage visible. When a direct request-derived source is visible in the same expression, the finding may include a structural `evidencePath` such as `request.json()`; this is bounded evidence, not full taint tracking. The rule does not prove that a value is user-controlled, and findings remain review signals rather than proof of exploitation.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -14,8 +14,9 @@ The 323-package-test count above is the frozen #13 pre-implementation
 baseline. The post-#14 validation count was 326 package tests, 146 web tests,
 and 472 total tests; see [phase-11-analysis-facts.md](./phase-11-analysis-facts.md).
 The #15 raw-SQL pilot recorded 337 package tests, 146 web tests, and 483 total
-tests; subsequent review hardening and the #19 reporter gate bring the current
-count to 340 package tests, 146 web tests, and 486 total tests. See
+tests; subsequent review hardening, the #19 reporter gate, and the #16 XSS
+refinement bring the current count to 342 package tests, 146 web tests, and
+488 total tests. See
 [phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md) and
 [phase-13-v05-release-gate.md](./phase-13-v05-release-gate.md).
 
@@ -57,6 +58,10 @@ fixture stability, and directional performance sample are documented in
 The #19 regression, benchmark, deterministic-output, public-privacy, and pack
 release gate are documented in
 [phase-13-v05-release-gate.md](./phase-13-v05-release-gate.md).
+
+The #16 XSS source/sanitizer refinement, documented sanitizer allowlist,
+bounded request-source evidence, and unknown-wrapper regression cases are
+documented in [phase-14-xss-refinement.md](./phase-14-xss-refinement.md).
 
 ## Post-release Real-world Smoke Note
 

--- a/docs/validation/phase-14-xss-refinement.md
+++ b/docs/validation/phase-14-xss-refinement.md
@@ -1,0 +1,77 @@
+# Phase 14: XSS Source and Sanitizer Refinement
+
+Date: 2026-08-29
+
+Issue: [#16](https://github.com/SetraTheXX/next-secure-check/issues/16)
+
+## Purpose
+
+This note records the bounded refinement of
+`xss/dangerously-set-inner-html`. The rule keeps JSX attribute syntax as its
+first boundary, leaves variable and member-expression values visible, excludes
+static HTML literals, and trusts only a small documented sanitizer allowlist.
+
+The implementation does not execute scanned code, load project TypeScript
+types, build a cross-file graph, or claim that a finding proves exploitability.
+Findings remain deterministic review signals.
+
+## Sanitizer boundary
+
+The recognized syntax-only cases are:
+
+- `DOMPurify.sanitize(...)`.
+- direct `sanitizeHtml(...)` and `sanitizeMarkdown(...)` calls.
+- default imports from `dompurify` and `sanitize-html`, including aliases used
+  with `.sanitize(...)`.
+- same-file `const` values derived from a recognized literal or sanitizer call.
+
+Generic `sanitize(...)`, `sanitizeContent(...)`, `toSafeHtml(...)`, arbitrary
+`wrapper.sanitize(...)`, and sanitizer-looking imports from unknown local modules
+remain findings. The analyzer does not silently trust custom wrappers because
+their implementation cannot be proven in the syntax-only boundary.
+
+## Bounded source evidence
+
+The shared `AnalysisFacts` source collection is reused for direct request-derived
+expressions visible inside the `__html` value. For example, a direct
+`request.json()` expression can carry `evidencePath: "request.json()"` to the
+finding and supported reports. This is structural evidence only; aliases across
+function boundaries, cross-file flow, mutation, and a universal sanitizer trust
+model remain out of scope.
+
+## Regression coverage
+
+The rules suite covers:
+
+- variable and member-expression values staying at MEDIUM severity;
+- static literals, ordinary JSX text, and unrelated props staying clean;
+- `DOMPurify.sanitize`, `sanitizeHtml`, `sanitizeMarkdown`, and known package
+  aliases staying clean;
+- six unknown wrapper forms remaining MEDIUM findings;
+- direct `request.json()` evidence reaching the XSS finding;
+- existing context tuning and strict/audit preset contracts remaining explicit.
+
+## Validation evidence
+
+The full local sequence passed:
+
+```text
+pnpm build       PASS
+pnpm typecheck   PASS
+pnpm lint        PASS
+pnpm test        PASS — 342 package tests, 146 web tests, 488 total
+```
+
+The v0.5 release gate also passed without changing the frozen fixture
+inventories:
+
+```text
+pnpm release:gate PASS
+vulnerable fixture: 0/100, critical, 26 findings
+secure fixture: 99/100, excellent, 1 LOW finding
+self-scan: 100/100, excellent, 0 findings
+```
+
+The gate continued to validate deterministic JSON/SARIF, concise summary line
+limits, public-output privacy, pack dry-run, and the small/medium benchmark
+corpus. No fixture result changed as a side effect of this XSS refinement.

--- a/packages/rules/src/ast-utils.ts
+++ b/packages/rules/src/ast-utils.ts
@@ -38,6 +38,7 @@ export type AnalysisFacts = {
   safeCommandCalls: ReadonlySet<ts.CallExpression>;
   routeHandlerNodes: readonly ts.Node[];
   sanitizerIdentifiers: ReadonlySet<string>;
+  untrustedSanitizerIdentifiers: ReadonlySet<string>;
   safeHtmlIdentifiers: ReadonlySet<string>;
   hasPasswordHashing: boolean;
   hasAuthIntent: boolean;
@@ -109,11 +110,18 @@ export function findRawSqlConcatMatches(file: SourceFile): AstMatch[] {
 }
 
 export function findDangerouslySetInnerHtmlMatches(file: SourceFile): DangerouslySetInnerHtmlMatch[] {
-  const { sourceFile, sanitizerIdentifiers, safeHtmlIdentifiers } = getAnalysisFacts(file);
+  const { sourceFile, boundedFlow, sanitizerIdentifiers, untrustedSanitizerIdentifiers, safeHtmlIdentifiers } = getAnalysisFacts(file);
   return dedupeMatches(
-    findDangerouslySetInnerHtmlNodes(sourceFile, sanitizerIdentifiers, safeHtmlIdentifiers).map(({ node, severity }) => ({
+    findDangerouslySetInnerHtmlNodes(
+      sourceFile,
+      sanitizerIdentifiers,
+      safeHtmlIdentifiers,
+      boundedFlow,
+      untrustedSanitizerIdentifiers
+    ).map(({ node, severity, evidencePath }) => ({
       ...matchFromNode(file, sourceFile, node),
-      severity
+      severity,
+      ...(evidencePath ? { evidencePath } : {})
     }))
   );
 }
@@ -190,6 +198,7 @@ function createAnalysisFacts(sourceFile: ts.SourceFile): AnalysisFacts {
     safeCommandCalls: commandFlow.safeCommandCalls,
     routeHandlerNodes,
     sanitizerIdentifiers: xssFacts.sanitizerIdentifiers,
+    untrustedSanitizerIdentifiers: xssFacts.untrustedSanitizerIdentifiers,
     safeHtmlIdentifiers: xssFacts.safeHtmlIdentifiers,
     hasPasswordHashing: hasPasswordHashingCall(sourceFile),
     hasAuthIntent: hasAuthIntentInSource(sourceFile),

--- a/packages/rules/src/security-rules.test.ts
+++ b/packages/rules/src/security-rules.test.ts
@@ -132,8 +132,6 @@ describe("built-in security rules", () => {
         "    <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />",
         "    <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(markdown) }} />",
         "    <div dangerouslySetInnerHTML={{ __html: sanitizeMarkdown(markdown) }} />",
-        "    <div dangerouslySetInnerHTML={{ __html: sanitizeContent(markdown) }} />",
-        "    <div dangerouslySetInnerHTML={{ __html: toSafeHtml(markdown) }} />",
         "  </>;",
         "}"
       ].join("\n")
@@ -147,18 +145,58 @@ describe("built-in security rules", () => {
       "app/page.tsx": [
         'import sanitizeHtml from "sanitize-html";',
         'import purifier from "dompurify";',
-        'import { sanitize as sanitizeMarkdownContent } from "./sanitize";',
+        'import { sanitizeHtml as sanitizePackageHtml } from "sanitize-html";',
         "export default function Page({ html, markdown }) {",
         "  return <>",
         "    <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }} />",
         "    <div dangerouslySetInnerHTML={{ __html: purifier.sanitize(html) }} />",
-        "    <div dangerouslySetInnerHTML={{ __html: sanitizeMarkdownContent(markdown) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: sanitizePackageHtml(markdown) }} />",
         "  </>;",
         "}"
       ].join("\n")
     });
 
     expect(result.findings.some((finding) => finding.ruleId === "xss/dangerously-set-inner-html")).toBe(false);
+  });
+
+  it("does not trust unknown dangerouslySetInnerHTML sanitizer wrappers", async () => {
+    const result = await scanFixture({
+      "app/page.tsx": [
+        'import { sanitize as localSanitize } from "./sanitize";',
+        'import { sanitizeHtml } from "./sanitize";',
+        "export default function Page({ html, markdown }) {",
+        "  return <>",
+        "    <div dangerouslySetInnerHTML={{ __html: localSanitize(html) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: sanitize(markdown) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: sanitizeContent(markdown) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: toSafeHtml(markdown) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: customSanitizer(markdown) }} />",
+        "    <div dangerouslySetInnerHTML={{ __html: renderer.sanitize(markdown) }} />",
+        "  </>;",
+        "}"
+      ].join("\n")
+    });
+    const findings = result.findings.filter((finding) => finding.ruleId === "xss/dangerously-set-inner-html");
+
+    expect(findings).toHaveLength(7);
+    expect(findings.every((finding) => finding.severity === "MEDIUM")).toBe(true);
+  });
+
+  it("adds bounded source evidence for direct request-derived HTML", async () => {
+    const result = await scanFixture({
+      "app/page.tsx": [
+        "export default function Page({ request }) {",
+        "  return <main dangerouslySetInnerHTML={{ __html: request.json() }} />;",
+        "}"
+      ].join("\n")
+    });
+    const finding = result.findings.find((item) => item.ruleId === "xss/dangerously-set-inner-html");
+
+    expect(finding).toMatchObject({
+      severity: "MEDIUM",
+      evidencePath: "request.json()"
+    });
   });
 
   it("does not flag same-file static or sanitized HTML constants", async () => {

--- a/packages/rules/src/security-rules.ts
+++ b/packages/rules/src/security-rules.ts
@@ -169,6 +169,7 @@ export const dangerouslySetInnerHtmlRule: Rule = {
           line: match.line,
           column: match.column,
           evidence: match.evidence,
+          evidencePath: match.evidencePath,
           description: "Rendering raw HTML can introduce XSS if the content is user-controlled.",
           recommendation: "Avoid raw HTML rendering or sanitize trusted markup with a proven sanitizer."
         })

--- a/packages/rules/src/xss-ast.ts
+++ b/packages/rules/src/xss-ast.ts
@@ -1,32 +1,40 @@
 import ts from "typescript";
+import type { BoundedFlowFacts } from "./analysis-facts.js";
 
 const SANITIZER_MODULE_PATTERN = /^(?:dompurify|sanitize-html)$/i;
+const SANITIZER_FUNCTION_PATTERN = /^(?:sanitizeHtml|sanitizeMarkdown)$/i;
+const SANITIZER_METHOD_NAME = "sanitize";
 
 export type XssSeverity = "LOW" | "MEDIUM";
 
 export type XssAnalysisFacts = {
   sanitizerIdentifiers: ReadonlySet<string>;
+  untrustedSanitizerIdentifiers: ReadonlySet<string>;
   safeHtmlIdentifiers: ReadonlySet<string>;
 };
 
 export type DangerouslySetInnerHtmlNode = {
   node: ts.JsxAttribute;
   severity: XssSeverity;
+  evidencePath?: string;
 };
 
 export function createXssAnalysisFacts(sourceFile: ts.SourceFile): XssAnalysisFacts {
-  const sanitizerIdentifiers = collectSanitizerIdentifiers(sourceFile);
+  const { sanitizerIdentifiers, untrustedSanitizerIdentifiers } = collectSanitizerIdentifiers(sourceFile);
 
   return {
     sanitizerIdentifiers,
-    safeHtmlIdentifiers: collectSafeHtmlIdentifiers(sourceFile, sanitizerIdentifiers)
+    untrustedSanitizerIdentifiers,
+    safeHtmlIdentifiers: collectSafeHtmlIdentifiers(sourceFile, sanitizerIdentifiers, untrustedSanitizerIdentifiers)
   };
 }
 
 export function findDangerouslySetInnerHtmlNodes(
   sourceFile: ts.SourceFile,
   sanitizerIdentifiers: ReadonlySet<string>,
-  safeHtmlIdentifiers: ReadonlySet<string>
+  safeHtmlIdentifiers: ReadonlySet<string>,
+  boundedFlow: BoundedFlowFacts,
+  untrustedSanitizerIdentifiers: ReadonlySet<string>
 ): DangerouslySetInnerHtmlNode[] {
   const matches: DangerouslySetInnerHtmlNode[] = [];
 
@@ -35,9 +43,16 @@ export function findDangerouslySetInnerHtmlNodes(
       return;
     }
 
-    const severity = dangerouslySetInnerHtmlSeverity(node.initializer, sanitizerIdentifiers, safeHtmlIdentifiers);
+    const severity = dangerouslySetInnerHtmlSeverity(
+      node.initializer,
+      sanitizerIdentifiers,
+      safeHtmlIdentifiers,
+      untrustedSanitizerIdentifiers
+    );
     if (severity) {
-      matches.push({ node, severity });
+      const valueExpression = dangerouslySetInnerHtmlValueExpression(node.initializer);
+      const evidencePath = valueExpression ? findBoundedSourcePath(valueExpression, boundedFlow) : undefined;
+      matches.push({ node, severity, ...(evidencePath ? { evidencePath } : {}) });
     }
   });
 
@@ -47,7 +62,8 @@ export function findDangerouslySetInnerHtmlNodes(
 function dangerouslySetInnerHtmlSeverity(
   initializer: ts.JsxAttribute["initializer"],
   sanitizerIdentifiers: ReadonlySet<string>,
-  safeHtmlIdentifiers: ReadonlySet<string>
+  safeHtmlIdentifiers: ReadonlySet<string>,
+  untrustedSanitizerIdentifiers: ReadonlySet<string>
 ): XssSeverity | undefined {
   if (!initializer || ts.isStringLiteral(initializer)) {
     return undefined;
@@ -66,15 +82,23 @@ function dangerouslySetInnerHtmlSeverity(
     .filter(ts.isPropertyAssignment)
     .find((property) => propertyNameText(property.name) === "__html")?.initializer;
 
-  if (!htmlExpression || isStaticHtmlExpression(htmlExpression, safeHtmlIdentifiers) || isSanitizedHtmlExpression(htmlExpression, sanitizerIdentifiers)) {
+  if (
+    !htmlExpression ||
+    isStaticHtmlExpression(htmlExpression, safeHtmlIdentifiers) ||
+    isSanitizedHtmlExpression(htmlExpression, sanitizerIdentifiers, untrustedSanitizerIdentifiers)
+  ) {
     return undefined;
   }
 
   return "MEDIUM";
 }
 
-function collectSanitizerIdentifiers(sourceFile: ts.SourceFile): Set<string> {
+function collectSanitizerIdentifiers(sourceFile: ts.SourceFile): {
+  sanitizerIdentifiers: Set<string>;
+  untrustedSanitizerIdentifiers: Set<string>;
+} {
   const sanitizerIdentifiers = new Set<string>();
+  const untrustedSanitizerIdentifiers = new Set<string>();
 
   visitXssNodes(sourceFile, (node) => {
     if (!ts.isImportDeclaration(node) || !ts.isStringLiteralLike(node.moduleSpecifier)) {
@@ -82,13 +106,16 @@ function collectSanitizerIdentifiers(sourceFile: ts.SourceFile): Set<string> {
     }
 
     const moduleName = node.moduleSpecifier.text;
+    const isKnownSanitizerModule = SANITIZER_MODULE_PATTERN.test(moduleName);
     const importClause = node.importClause;
     if (!importClause) {
       return;
     }
 
-    if (importClause.name && SANITIZER_MODULE_PATTERN.test(moduleName)) {
+    if (importClause.name && isKnownSanitizerModule) {
       sanitizerIdentifiers.add(importClause.name.text);
+    } else if (importClause.name && isSanitizerFunctionName(importClause.name.text)) {
+      untrustedSanitizerIdentifiers.add(importClause.name.text);
     }
 
     const namedBindings = importClause.namedBindings;
@@ -97,17 +124,24 @@ function collectSanitizerIdentifiers(sourceFile: ts.SourceFile): Set<string> {
     }
 
     for (const importSpecifier of namedBindings.elements) {
+      const localName = importSpecifier.name.text;
       const importedName = importSpecifier.propertyName?.text ?? importSpecifier.name.text;
-      if (isSanitizerFunctionName(importedName)) {
-        sanitizerIdentifiers.add(importSpecifier.name.text);
+      if (isKnownSanitizerModule && isSanitizerFunctionName(importedName)) {
+        sanitizerIdentifiers.add(localName);
+      } else if (!isKnownSanitizerModule && isSanitizerFunctionName(localName)) {
+        untrustedSanitizerIdentifiers.add(localName);
       }
     }
   });
 
-  return sanitizerIdentifiers;
+  return { sanitizerIdentifiers, untrustedSanitizerIdentifiers };
 }
 
-function collectSafeHtmlIdentifiers(sourceFile: ts.SourceFile, sanitizerIdentifiers: Set<string>): Set<string> {
+function collectSafeHtmlIdentifiers(
+  sourceFile: ts.SourceFile,
+  sanitizerIdentifiers: Set<string>,
+  untrustedSanitizerIdentifiers: Set<string>
+): Set<string> {
   const safeHtmlIdentifiers = new Set<string>();
 
   visitXssNodes(sourceFile, (node) => {
@@ -120,7 +154,10 @@ function collectSafeHtmlIdentifiers(sourceFile: ts.SourceFile, sanitizerIdentifi
         continue;
       }
 
-      if (isStaticHtmlExpression(declaration.initializer, safeHtmlIdentifiers) || isSanitizedHtmlExpression(declaration.initializer, sanitizerIdentifiers)) {
+      if (
+        isStaticHtmlExpression(declaration.initializer, safeHtmlIdentifiers) ||
+        isSanitizedHtmlExpression(declaration.initializer, sanitizerIdentifiers, untrustedSanitizerIdentifiers)
+      ) {
         safeHtmlIdentifiers.add(declaration.name.text);
       }
     }
@@ -141,24 +178,70 @@ function isStaticHtmlExpression(expression: ts.Expression, safeHtmlIdentifiers: 
   return ts.isStringLiteralLike(expression) || ts.isNoSubstitutionTemplateLiteral(expression) || (ts.isIdentifier(expression) && safeHtmlIdentifiers.has(expression.text));
 }
 
-function isSanitizedHtmlExpression(expression: ts.Expression, sanitizerIdentifiers: ReadonlySet<string>): boolean {
+function isSanitizedHtmlExpression(
+  expression: ts.Expression,
+  sanitizerIdentifiers: ReadonlySet<string>,
+  untrustedSanitizerIdentifiers: ReadonlySet<string>
+): boolean {
   if (!ts.isCallExpression(expression)) {
     return false;
   }
 
   if (ts.isIdentifier(expression.expression)) {
-    return sanitizerIdentifiers.has(expression.expression.text) || isSanitizerFunctionName(expression.expression.text);
+    return (
+      sanitizerIdentifiers.has(expression.expression.text) ||
+      (!untrustedSanitizerIdentifiers.has(expression.expression.text) && isSanitizerFunctionName(expression.expression.text))
+    );
   }
 
   if (ts.isPropertyAccessExpression(expression.expression)) {
-    return isSanitizerFunctionName(expression.expression.name.text);
+    const receiver = expression.expression.expression;
+    return (
+      expression.expression.name.text === SANITIZER_METHOD_NAME &&
+      ts.isIdentifier(receiver) &&
+      (receiver.text === "DOMPurify" || sanitizerIdentifiers.has(receiver.text))
+    );
   }
 
   return false;
 }
 
 function isSanitizerFunctionName(name: string): boolean {
-  return /^(?:sanitize|sanitizeHtml|sanitizeMarkdown|sanitizeContent|toSafeHtml)$/i.test(name);
+  return SANITIZER_FUNCTION_PATTERN.test(name);
+}
+
+function dangerouslySetInnerHtmlValueExpression(initializer: ts.JsxAttribute["initializer"]): ts.Expression | undefined {
+  if (!initializer || !ts.isJsxExpression(initializer) || !initializer.expression) {
+    return undefined;
+  }
+
+  if (!ts.isObjectLiteralExpression(initializer.expression)) {
+    return initializer.expression;
+  }
+
+  return initializer.expression.properties
+    .filter(ts.isPropertyAssignment)
+    .find((property) => propertyNameText(property.name) === "__html")?.initializer;
+}
+
+function findBoundedSourcePath(expression: ts.Node, boundedFlow: BoundedFlowFacts): string | undefined {
+  const directSource = boundedFlow.sources.find((source) => source.node === expression);
+  if (directSource) {
+    return directSource.path;
+  }
+
+  if (ts.isFunctionLike(expression)) {
+    return undefined;
+  }
+
+  let evidencePath: string | undefined;
+  ts.forEachChild(expression, (child) => {
+    if (!evidencePath) {
+      evidencePath = findBoundedSourcePath(child, boundedFlow);
+    }
+  });
+
+  return evidencePath;
 }
 
 function visitXssNodes(node: ts.Node, callback: (node: ts.Node) => void): void {


### PR DESCRIPTION
Closes #16. Tightens dangerouslySetInnerHTML sanitizer recognition to a documented allowlist, keeps unknown wrappers as review findings, and carries bounded direct request-source evidence. Adds regression coverage plus rule, README, roadmap, changelog, and Phase 14 validation documentation. Validation passed: pnpm build, pnpm typecheck, pnpm lint, pnpm test (342 package + 146 web), and pnpm release:gate.