### PR TITLE
feat: improve evidence reporter explanations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the first raw SQL bounded source-to-sink slice for recognized query sinks, SQL-valued local aliases, dynamic string concatenation, and optional source evidence paths.
 - Added structural auth, route-handler, and rate-limit intent signals for App Router, Pages Router, and same-app middleware checks.
 - Added the v0.5 regression/performance release gate for fixture inventories, deterministic reports, concise summaries, public-output privacy, benchmarks, and CLI pack dry-runs.
+- Added bounded finding explanations to detailed terminal, Markdown, GitHub, and web exports, including `Why`, context reason, and proven `evidencePath` metadata.
 
 ### Changed
 - Refined `xss/dangerously-set-inner-html` with a documented sanitizer allowlist and bounded evidence paths for direct request-derived values.
 - Refined authentication and validation rules so UI paths, comments, strings, unused helpers, and unknown local wrappers do not silently suppress endpoint findings.
+- Extended `explain <rule-id>` with explicit false-negative boundaries for bounded flow, dynamic resolution, and external controls; SARIF now exposes the normalized `whyReported` property while preserving existing identities and fingerprints.
 
 ### Documentation
 - Added the reproducible VHS README demo, simplified SVG wordmark, and v0.5 summary-output validation note.
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the Phase 13 validation note with the repeatable 100/1,000-file cold/warm benchmark protocol and release-gate evidence.
 - Added the Phase 14 XSS source/sanitizer refinement validation note for issue #16.
 - Added the Phase 15 auth/middleware intent validation note for issue #17.
+- Added the Phase 16 evidence and reporter explanation validation note for issue #18.
 
 ### Fixed
 - Fixed direct route-parameter command sources so they populate the shared bounded-flow source facts as well as the existing evidence path.
@@ -40,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed auth/rate-limit intent from unrelated helpers, generic role-property reads, unbound or incorrectly aliased `auth` imports, and partially protected multi-handler route files.
 
 ### Tests
-- Current validation baseline: 362 package tests, 146 web tests, 508 total tests.
+- Current validation baseline: 366 package tests, 147 web tests, 513 total tests.
 - Dependency audit is clean after pinning the test-only Vite peer to patched `8.0.16`.
 
 ## [0.4.1] - 2026-08-24

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ next-secure-check scans a local project and reports common security mistakes bef
 ## Why use it?
 
 - Run a quick security sanity check with one `npx` command.
-- Get deterministic findings with severity, confidence, location, context, evidence, and recommendations.
+- Get deterministic findings with severity, confidence, location, context, bounded evidence paths, and recommendations.
 - Use the same scanner locally, in GitHub Actions, or through SARIF-compatible Code Scanning workflows.
 
 It is a lightweight pre-release review signal, not a penetration test or a replacement for a full security audit.
@@ -139,6 +139,11 @@ npx --yes next-secure-check@latest init
 
 `init` creates `.next-secure-check.json` and `.github/workflows/next-secure-check.yml`. Existing files are skipped by default; use `--force` only when you intentionally want to overwrite them.
 
+`explain` also documents the review boundary for each built-in rule. Its output
+includes false-positive notes and false-negative boundaries, including the
+intentional limits of same-function bounded flow, short alias chains, dynamic
+resolution, and external middleware or infrastructure controls.
+
 ## Presets
 
 Presets choose a practical coverage and noise tradeoff. They do not replace manual review.
@@ -208,7 +213,11 @@ The web demo does not read config files from scanned repositories. Its public-re
 
 ## Findings and SARIF
 
-Findings include a rule ID, title, severity, confidence, file location, context, recommendation, and safe evidence when available. Context values such as `api-code`, `test-code`, or `release-tooling` explain how the scanner classified a path.
+Findings include a rule ID, title, severity, confidence, file location, context,
+an explanation of why the pattern was reported, and a recommendation. When the
+syntax proves a bounded source-to-sink path, the finding also carries a concise
+`evidencePath` such as `request.json() -> query`. That path is evidence of the
+recognized syntax only; it is not proof that an exploit exists.
 
 SARIF 2.1.0 output includes:
 
@@ -218,9 +227,17 @@ SARIF 2.1.0 output includes:
 - `security-severity` and precision metadata
 - deterministic `partialFingerprints`
 - context and context-reason properties
+- `whyReported` and optional `evidencePath` result properties
 - concise messages built from the title, description, and recommendation
 
-Raw secret evidence is replaced with `[REDACTED]` in JSON, terminal, and Markdown output and is not embedded in SARIF; GitHub output also omits evidence details. Findings are review signals, not proof that an exploit exists; review the confidence, evidence, and recommendation before treating one as a confirmed vulnerability.
+Detailed terminal and Markdown reports show `Why`, `Context reason`, and an
+optional `Evidence path`. GitHub keeps its findings table compact and places
+the same explanation metadata in its recommendations details; it intentionally
+omits raw evidence. The web Markdown export follows the same explanation
+contract. Raw secret evidence is replaced with `[REDACTED]` in JSON, terminal,
+and Markdown output and is not embedded in SARIF. Findings are review signals,
+not proof that an exploit exists; review the confidence, evidence path, and
+recommendation before treating one as a confirmed vulnerability.
 
 ## Reproducible Demo
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Public progress board for `next-secure-check`. It records completed release work
 | Last reviewed | 2026-08-29 |
 | Current release | `v0.4.1` published |
 | Next release focus | `v0.5.0` - explainable bounded analysis |
-| Current next task | v0.5 Phase 5 - Evidence and reporter explanations (#18) |
+| Current next task | v0.5 Phase 7 - Release and feedback loop (#20) |
 | Release blocker | None for the published line; issue #12 is optional demo/media follow-up |
 
 ## Progress Legend
@@ -24,7 +24,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] `v0.4.0` published as the bounded-analysis feature release.
 - [x] `v0.4.1` published as the CLI documentation-only patch.
 - [x] npm package, workspace package metadata, GitHub Actions validation, pack smoke, and release documentation completed.
-- [x] Current validation baseline: 362 package tests, 146 web tests, 508 total tests.
+- [x] Current validation baseline: 366 package tests, 147 web tests, 513 total tests.
 - [x] Repository self-scan with `--preset app`: 100/100, `excellent`, 0 findings.
 - [x] Vulnerable fixture with `--preset strict`: 0/100, `critical`, 26 findings.
 - [x] Secure fixture with `--preset app`: 99/100, `excellent`, 1 LOW finding.
@@ -48,6 +48,7 @@ A checked item means the implementation or documentation exists and the relevant
 - [x] [v0.5 raw SQL bounded-flow validation](./docs/validation/phase-12-raw-sql-bounded-flow.md)
 - [x] [v0.5 regression and performance release gate](./docs/validation/phase-13-v05-release-gate.md)
 - [x] [v0.5 auth and middleware intent](./docs/validation/phase-15-auth-middleware.md)
+- [x] [v0.5 evidence and reporter explanations](./docs/validation/phase-16-evidence-reporter.md)
 - [x] [v0.4.1 GitHub release](https://github.com/SetraTheXX/next-secure-check/releases/tag/v0.4.1)
 - [x] [release history](./CHANGELOG.md)
 
@@ -167,7 +168,7 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 - [x] [#15 Raw SQL bounded source-to-sink pilot](https://github.com/SetraTheXX/next-secure-check/issues/15)
 - [x] [#16 XSS source and sanitizer refinement](https://github.com/SetraTheXX/next-secure-check/issues/16)
 - [x] [#17 Auth and middleware intent signals](https://github.com/SetraTheXX/next-secure-check/issues/17)
-- [ ] [#18 Evidence and reporter explanations](https://github.com/SetraTheXX/next-secure-check/issues/18)
+- [x] [#18 Evidence and reporter explanations](https://github.com/SetraTheXX/next-secure-check/issues/18)
 - [x] [#19 Regression and performance release gate](https://github.com/SetraTheXX/next-secure-check/issues/19)
 - [ ] [#20 v0.5 release and feedback loop](https://github.com/SetraTheXX/next-secure-check/issues/20)
 
@@ -283,17 +284,17 @@ The first production slice should be a bounded `injection/raw-sql-concat` flow b
 
 ## v0.5 Phase 5 - Evidence and reporter UX (#18)
 
-- [ ] **Phase status:** Planned
+- [x] **Phase status:** Complete; implementation and validation recorded in [phase-16-evidence-reporter.md](./docs/validation/phase-16-evidence-reporter.md)
 
 **Purpose:** Make a finding easier to review without changing its rule identity or report contract.
 
-- [ ] Show a concise source-to-sink evidence path when one is proven.
-- [ ] Keep context and context reason visible in JSON, terminal, Markdown, GitHub, and SARIF outputs.
-- [ ] Keep raw secrets, tokens, local paths, and stack traces out of user-facing output.
-- [ ] Improve `explain` guidance for common false-positive and false-negative boundaries.
+- [x] Show a concise source-to-sink evidence path when one is proven.
+- [x] Keep context and context reason visible in JSON, terminal, Markdown, GitHub, and SARIF outputs.
+- [x] Keep raw secrets, tokens, local paths, and stack traces out of user-facing output.
+- [x] Improve `explain` guidance for common false-positive and false-negative boundaries.
 - [x] Provide an opt-in concise terminal summary for quick reviews and README demos while preserving the detailed default report.
-- [ ] Add deterministic reporter tests for evidence paths, empty findings, SARIF fingerprints, and secret redaction.
-- [ ] Avoid adding a new output format when existing formats can carry the information.
+- [x] Add deterministic reporter tests for evidence paths, empty findings, SARIF fingerprints, and secret redaction.
+- [x] Avoid adding a new output format when existing formats can carry the information.
 
 **Exit criteria:** A reviewer can answer “why was this reported?” from the result itself without mistaking the evidence for proof of exploitation.
 
@@ -356,7 +357,7 @@ These are valuable, but should not block the v0.5 bounded-analysis quality work:
 4. [x] v0.5 Phase 6 - regression and performance gate for the SQL pilot.
 5. [x] v0.5 Phase 3 - XSS source/sanitizer refinement.
 6. [x] v0.5 Phase 4 - auth and middleware intent.
-7. [ ] v0.5 Phase 5 - evidence/reporting polish.
+7. [x] v0.5 Phase 5 - evidence/reporting polish.
 8. [ ] v0.5 Phase 7 - release and feedback loop.
 
 This order deliberately puts measurement before deeper analysis. It also keeps TypeChecker and plugins out of the default path until real corpus evidence shows that their accuracy value justifies their cost.

--- a/apps/web/app/page.test.tsx
+++ b/apps/web/app/page.test.tsx
@@ -96,6 +96,29 @@ describe("Home scan UI helpers", () => {
     expect(exported).toContain("secrets/hardcoded");
   });
 
+  it("includes finding explanations and bounded evidence in Markdown exports", () => {
+    const result = createSuccessResult([
+      createFinding({
+        category: "injection",
+        context: "api-code",
+        contextReason: "matched Next.js API route path",
+        description: "SQL query uses request input.",
+        evidence: "db.query(sql)",
+        evidencePath: "request.json() -> query",
+        ruleId: "injection/raw-sql-concat"
+      })
+    ]);
+    const exported = createScanMarkdownExport(result);
+    const indexed = createResultTextIndex(result).join(" ");
+
+    expect(exported).toContain("- Why: SQL query uses request input.");
+    expect(exported).toContain("- Context: `api-code`");
+    expect(exported).toContain("- Context reason: matched Next.js API route path");
+    expect(exported).toContain("- Evidence path: `request.json() -> query`");
+    expect(indexed).toContain("matched Next.js API route path");
+    expect(indexed).toContain("request.json() -> query");
+  });
+
   it("does not include raw secret evidence in exports", () => {
     const result = createSuccessResult();
 

--- a/apps/web/lib/scan-ui.ts
+++ b/apps/web/lib/scan-ui.ts
@@ -1,3 +1,4 @@
+import type { FindingContext } from "@next-secure-check/core";
 import { parseGitHubRepoUrl } from "./github-url";
 
 export type ScanStatus = "idle" | "loading" | "success" | "error";
@@ -10,9 +11,12 @@ export type ScanApiFinding = {
   confidence: "HIGH" | "MEDIUM" | "LOW";
   category: string;
   filePath: string;
+  context?: FindingContext;
+  contextReason?: string;
   line?: number;
   column?: number;
   evidence?: string;
+  evidencePath?: string;
   description: string;
   recommendation: string;
   references?: string[];
@@ -119,7 +123,11 @@ export function createResultTextIndex(result: ScanApiSuccess): string[] {
       finding.ruleId,
       finding.severity,
       finding.confidence,
+      finding.context ?? "unknown",
+      finding.contextReason ?? "",
       formatFindingLocation(finding),
+      finding.evidencePath ?? "",
+      finding.description,
       finding.evidence ?? "",
       finding.recommendation
     ]),
@@ -160,8 +168,16 @@ export function createScanMarkdownExport(result: ScanApiSuccess): string {
       `- Severity: ${finding.severity}`,
       `- Confidence: ${finding.confidence}`,
       `- Location: ${formatFindingLocation(finding)}`,
-      `- Recommendation: ${finding.recommendation}`
+      `- Context: \`${formatInlineText(finding.context ?? "unknown")}\``,
+      `- Why: ${formatInlineText(finding.description)}`,
+      `- Context reason: ${formatInlineText(finding.contextReason ?? "no context metadata available")}`
     );
+
+    if (finding.evidencePath) {
+      lines.push(`- Evidence path: \`${escapeBackticks(formatInlineText(finding.evidencePath))}\``);
+    }
+
+    lines.push(`- Recommendation: ${finding.recommendation}`);
 
     if (finding.evidence) {
       lines.push("", "```text", finding.evidence, "```");
@@ -171,4 +187,12 @@ export function createScanMarkdownExport(result: ScanApiSuccess): string {
   });
 
   return lines.join("\n").trimEnd();
+}
+
+function formatInlineText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function escapeBackticks(value: string): string {
+  return value.replaceAll("`", "'");
 }

--- a/docs/decisions/0002-v0.5-bounded-flow-contract.md
+++ b/docs/decisions/0002-v0.5-bounded-flow-contract.md
@@ -66,12 +66,12 @@ The existing public report formats remain compatible:
 
 | Format | Baseline contract |
 | --- | --- |
-| Detailed terminal | Human-readable project metadata, score/risk, severity sections, rule ID, location, confidence, context, and optional evidence/recommendation blocks. |
+| Detailed terminal | Human-readable project metadata, score/risk, severity sections, rule ID, location, confidence, context, `Why`, context reason, and optional bounded evidence path/evidence/recommendation blocks. |
 | Concise terminal `--summary` | Opt-in terminal-only view with score/risk, counts, and up to three deterministically ordered representative findings. It omits evidence and fix paragraphs and does not change scan findings. |
 | JSON | Valid JSON containing project metadata, summary, findings, and scan metadata. Optional `evidencePath` is present only when a bounded path is proven. |
-| Markdown | Stable heading/summary/finding sections carrying the same finding identity and review metadata. |
-| GitHub | Step-summary-friendly headings, summary, findings, and recommendations without changing finding identity. |
-| SARIF | SARIF `2.1.0`, one tool run, rule/result metadata, locations when available, context properties, and deterministic `partialFingerprints`. |
+| Markdown | Stable heading/summary/finding sections carrying the same finding identity, `Why`, context reason, and optional bounded evidence path. |
+| GitHub | Step-summary-friendly headings, compact findings table, and recommendation details carrying explanation metadata and optional bounded evidence paths without changing finding identity. Raw evidence remains omitted. |
+| SARIF | SARIF `2.1.0`, one tool run, rule/result metadata, locations when available, context properties, optional `whyReported`/`evidencePath`, and deterministic `partialFingerprints`. |
 
 The `--summary` view is already implemented in the local development line;
 JSON, Markdown, GitHub, and SARIF behavior is unchanged by that presentation

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -18,10 +18,15 @@ tests; subsequent review hardening, the #19 reporter gate, and the #16 XSS
 refinement bring the count to 342 package tests, 146 web tests, and 488 total
  tests. The #17 auth/middleware intent work adds the current 20 regression
  checks, bringing the working-line count to 362 package tests, 146 web tests,
- and 508 total tests. See
+ and 508 total tests. Issue #18 reporter and web-export coverage brings the
+ current count to 366 package tests, 147 web tests, and 513 total tests. See
 [phase-12-raw-sql-bounded-flow.md](./phase-12-raw-sql-bounded-flow.md) and
 [phase-13-v05-release-gate.md](./phase-13-v05-release-gate.md) and
 [phase-15-auth-middleware.md](./phase-15-auth-middleware.md).
+
+The #18 evidence/reporter explanation contract, privacy behavior, bounded-path
+presentation, and CLI false-negative guidance are documented in
+[phase-16-evidence-reporter.md](./phase-16-evidence-reporter.md).
 
 Historical v0.1 baseline:
 

--- a/docs/validation/phase-16-evidence-reporter.md
+++ b/docs/validation/phase-16-evidence-reporter.md
@@ -1,0 +1,96 @@
+# Phase 16: Evidence and Reporter Explanations
+
+Date: 2026-08-29
+
+Issue: [#18](https://github.com/SetraTheXX/next-secure-check/issues/18)
+
+Status: Implemented on the v0.5 development line; the published npm line
+remains v0.4.1 until issue #20 is completed.
+
+## Purpose
+
+Make a finding easier to review without presenting bounded syntax evidence as
+proof of exploitability. The reporter keeps the existing rule IDs, CLI flags,
+output formats, SARIF locations, and deterministic fingerprint inputs.
+
+## Reporter contract
+
+- Detailed terminal and Markdown reports show `Why`, `Context reason`, and an
+  optional `Evidence path` when the analyzer proves a bounded source-to-sink
+  path.
+- The concise terminal `--summary` view remains intentionally short. It keeps
+  score, risk, counts, severity, confidence, context, and location, while
+  omitting evidence, explanation, and fix blocks.
+- JSON preserves `description`, context metadata, and optional `evidencePath`;
+  secret evidence remains `[REDACTED]`.
+- GitHub keeps the findings table compact and places explanation metadata in
+  the existing recommendations details. It does not add raw evidence to the
+  Step Summary; only a proven bounded path may be shown.
+- SARIF keeps `2.1.0`, existing locations, and deterministic fingerprints. Its
+  result message contains the title, description, and recommendation, while
+  result properties expose context, context reason, `whyReported`, redaction
+  state, and optional `evidencePath`.
+- The web JSON/Markdown export DTO and Markdown output carry the same context,
+  explanation, and bounded-path fields.
+
+## Explain guidance
+
+`next-secure-check explain <rule-id>` now includes both the existing false
+positive note and a false-negative boundary. Common guidance calls out:
+
+- same-function and short-alias limits for command and raw SQL flow;
+- cross-file, cross-function, dynamic-resolution, and custom-wrapper limits;
+- external middleware, WAF, hosting, and infrastructure controls that may not
+  be visible to a source scan; and
+- pattern-based secret detection that is not a complete credential inventory.
+
+## Privacy and determinism
+
+Raw secret evidence is redacted in JSON, terminal, Markdown, and web exports;
+SARIF does not embed raw evidence, and GitHub does not emit raw evidence. New
+explanation fields normalize line breaks for readable single-line metadata.
+`evidencePath` is emitted only from the existing bounded syntax facts and does
+not change finding IDs or SARIF fingerprint inputs.
+
+## Verification
+
+Focused reporter, CLI-helper, and web-export tests pass. The current full
+workspace test snapshot is:
+
+```text
+packages: 366 tests
+apps/web: 147 tests
+total: 513 tests
+```
+
+The established fixture expectations remain unchanged:
+
+| Scan | Expected result |
+| --- | --- |
+| `examples/vulnerable-next-app` with `--preset strict` | `0/100`, `critical`, 26 findings |
+| `examples/secure-next-app` with `--preset app` | `99/100`, `excellent`, 1 LOW finding |
+| repository self-scan with `--preset app` | `100/100`, `excellent`, 0 findings |
+
+The local v0.5 release gate passed after the reporter changes. Its repeatable
+benchmark snapshot was:
+
+```text
+100 files: cold scanner 117.6/119.8 ms median/p95; cold process 513.7/584.3 ms; warm 78/111.1 ms; overhead 1.12x
+1,000 files: cold scanner 832/843.7 ms median/p95; cold process 1221.5/1260.7 ms; warm 741.4/802.7 ms; overhead 1.09x
+warm scaling ratio: 9.50x
+```
+
+The release gate also passed fixture inventories, public-output privacy, SARIF
+determinism, CLI packaging dry-run, and concise-summary checks. Release
+publication/tagging and final GitHub CI validation remain part of issue #20.
+The README demo GIF remains the v0.5 development baseline and will be
+re-recorded after the final release feature set is frozen.
+
+## Intentional boundaries
+
+An evidence path describes recognized syntax, not runtime reachability or
+exploitability. Cross-file/interprocedural flow, full call graphs, dynamic
+resolution, heap aliasing, TypeChecker-backed analysis, and external controls
+remain outside this phase. A finding without `evidencePath` is still a review
+signal when a recognized sink or pattern was found; its absence is not a claim
+that the code is safe.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -90,6 +90,14 @@ describe("rules CLI helpers", () => {
     expect(output).toContain("Public client identifiers or browser-safe tokens can be intentional");
   });
 
+  it("explains bounded-flow false-negative boundaries", () => {
+    const output = formatRuleExplanation(getBuiltInRules(), "injection/raw-sql-concat");
+
+    expect(output).toContain("False negative boundary:");
+    expect(output).toContain("same function");
+    expect(output).toContain("cross-file");
+  });
+
   it("returns undefined and formats a helpful message for unknown rule ids", () => {
     const rules = getBuiltInRules();
 

--- a/packages/cli/src/rules-info.ts
+++ b/packages/cli/src/rules-info.ts
@@ -6,63 +6,75 @@ type RuleExplanation = {
   checks: string;
   why: string;
   falsePositiveNote: string;
+  falseNegativeNote: string;
 };
 
 const RULE_EXPLANATIONS: Record<string, RuleExplanation> = {
   "xss/dangerously-set-inner-html": {
     checks: "Flags dangerouslySetInnerHTML usage when the HTML source is not clearly static or sanitized.",
     why: "Rendering user-controlled HTML can lead to cross-site scripting in Next.js pages and components.",
-    falsePositiveNote: "Static HTML strings, sanitizer calls, and component/template contexts may be lower risk."
+    falsePositiveNote: "Static HTML strings, sanitizer calls, and component/template contexts may be lower risk.",
+    falseNegativeNote: "Cross-file values, dynamic component resolution, and custom sanitizer wrappers are not fully proven; a clean result does not prove every rendered HTML value is safe."
   },
   "auth/admin-route-without-auth": {
     checks: "Looks for admin-like API route handlers without local or middleware auth signals.",
     why: "Admin endpoints usually expose privileged data or actions and should require authentication and authorization.",
-    falsePositiveNote: "Middleware, framework conventions, or external gateways can protect a route even when the handler is minimal."
+    falsePositiveNote: "Middleware, framework conventions, or external gateways can protect a route even when the handler is minimal.",
+    falseNegativeNote: "The check does not build a full cross-file middleware or authorization graph; custom wrappers and external gateways may be missed."
   },
   "auth/login-without-rate-limit": {
     checks: "Looks for login/auth routes without route-level or matching middleware rate-limit signals.",
     why: "Authentication endpoints are common brute-force and credential-stuffing targets.",
-    falsePositiveNote: "Infrastructure-level rate limiting may not be visible to a static source scan."
+    falsePositiveNote: "Infrastructure-level rate limiting may not be visible to a static source scan.",
+    falseNegativeNote: "The check does not build a full cross-file middleware or infrastructure graph; custom rate-limit wrappers and external controls may be missed."
   },
   "auth/register-without-rate-limit": {
     checks: "Looks for register/signup routes without route-level or matching middleware rate-limit signals.",
     why: "Registration endpoints can be abused for spam accounts or resource exhaustion.",
-    falsePositiveNote: "Infrastructure-level abuse controls may not be visible to a static source scan."
+    falsePositiveNote: "Infrastructure-level abuse controls may not be visible to a static source scan.",
+    falseNegativeNote: "The check does not build a full cross-file middleware or infrastructure graph; custom abuse-control wrappers and external controls may be missed."
   },
   "injection/command-exec": {
     checks: "Flags child_process imports and calls such as exec, execSync, spawn, and spawnSync.",
     why: "Shell command execution can become command injection when arguments are user-controlled.",
-    falsePositiveNote: "CLI/release tooling can legitimately execute commands; presets/context tuning reduce that noise."
+    falsePositiveNote: "CLI/release tooling can legitimately execute commands; presets/context tuning reduce that noise.",
+    falseNegativeNote: "Bounded source-to-sink flow is limited to the same function and a small alias chain; cross-file, cross-function, and dynamically resolved execution paths may be missed."
   },
   "injection/raw-sql-concat": {
     checks: "Flags interpolated SQL templates passed to common query sinks.",
     why: "Interpolated SQL can expose applications to SQL injection.",
-    falsePositiveNote: "Static or parameterized queries are intentionally ignored."
+    falsePositiveNote: "Static or parameterized queries are intentionally ignored.",
+    falseNegativeNote: "Bounded source-to-sink flow is limited to the same function and at most two alias hops; cross-file, cross-function, and dynamically constructed query paths may be missed."
   },
   "secrets/hardcoded-secret": {
     checks: "Looks for high-signal hardcoded API keys, tokens, passwords, and provider token patterns.",
     why: "Committed secrets can be copied, leaked, and abused after publication.",
-    falsePositiveNote: "Obvious sample values are filtered, but rotate any real token that was committed."
+    falsePositiveNote: "Obvious sample values are filtered, but rotate any real token that was committed.",
+    falseNegativeNote: "Pattern matching does not cover every dynamically assembled or externally injected credential; a clean result is not a complete secret inventory."
   },
   "secrets/next-public-secret": {
     checks: "Flags NEXT_PUBLIC_ variable names containing secret-like terms; it does not prove that the assigned value is a credential.",
     why: "NEXT_PUBLIC_ values are exposed to browser-side code in Next.js, so credential-like values deserve review before shipping.",
-    falsePositiveNote: "Public client identifiers or browser-safe tokens can be intentional. Review the assigned value and audience, and rename the variable when practical."
+    falsePositiveNote: "Public client identifiers or browser-safe tokens can be intentional. Review the assigned value and audience, and rename the variable when practical.",
+    falseNegativeNote: "The rule is name- and context-based; secrets hidden behind computed names or other configuration channels may be missed."
   },
   "headers/missing-security-headers": {
     checks: "Looks for missing common security header configuration in Next.js apps.",
     why: "Security headers help reduce XSS, clickjacking, content sniffing, and referrer leakage risks.",
-    falsePositiveNote: "Headers configured outside the app, for example at a reverse proxy, may not be visible."
+    falsePositiveNote: "Headers configured outside the app, for example at a reverse proxy, may not be visible.",
+    falseNegativeNote: "Headers configured by reverse proxies, hosting, or dynamic runtime code may be missed."
   },
   "upload/missing-file-type-validation": {
     checks: "Looks for upload route handlers without file type validation signals.",
     why: "Uploads without type validation can allow unsafe file handling or unexpected content.",
-    falsePositiveNote: "Deep validation in shared helpers may not always be visible."
+    falsePositiveNote: "Deep validation in shared helpers may not always be visible.",
+    falseNegativeNote: "Validation implemented through shared helpers, middleware, or infrastructure may be missed."
   },
   "upload/missing-file-size-limit": {
     checks: "Looks for upload route handlers without file size limit signals.",
     why: "Uploads without size limits can cause resource exhaustion.",
-    falsePositiveNote: "Limits enforced by hosting or middleware may not be visible."
+    falsePositiveNote: "Limits enforced by hosting or middleware may not be visible.",
+    falseNegativeNote: "Limits enforced through shared helpers, middleware, hosting, or infrastructure may be missed."
   }
 };
 
@@ -114,6 +126,9 @@ export function formatRuleExplanation(rules: Rule[], ruleId: string): string | u
     "False positive note:",
     explanation.falsePositiveNote,
     "",
+    "False negative boundary:",
+    explanation.falseNegativeNote,
+    "",
     `Help: ${ruleHelpUri(rule.id)}`
   ].join("\n");
 }
@@ -147,7 +162,8 @@ function genericExplanation(rule: Rule): RuleExplanation {
   return {
     checks: `Runs the built-in ${rule.category} check named "${rule.title}".`,
     why: "The finding is a deterministic review signal for a security-relevant pattern.",
-    falsePositiveNote: "Review context, framework conventions, middleware, and deployment controls before treating it as confirmed risk."
+    falsePositiveNote: "Review context, framework conventions, middleware, and deployment controls before treating it as confirmed risk.",
+    falseNegativeNote: "Cross-file data flow, dynamic resolution, and external controls are outside this bounded static check and may be missed."
   };
 }
 

--- a/packages/reporter/src/index.test.ts
+++ b/packages/reporter/src/index.test.ts
@@ -39,7 +39,9 @@ describe("formatSummary", () => {
       "- MEDIUM validation/api-route-without-validation [confidence: MEDIUM, context: api-code] app/api/users/route.ts:12"
     );
     expect(summary).not.toContain("Evidence:");
+    expect(summary).not.toContain("Evidence path:");
     expect(summary).not.toContain("Fix:");
+    expect(summary).not.toContain("Why:");
   });
 
   it("limits the overview to deterministic top findings", () => {
@@ -78,6 +80,23 @@ describe("formatSummary", () => {
     expect(terminal).toContain("Fix: Add input validation.");
   });
 
+  it("explains bounded findings in the detailed terminal report", () => {
+    const result = createScanResultSkeleton("demo-app");
+    result.findings = [
+      {
+        ...createContextFinding(),
+        evidence: "db.query(sql)",
+        evidencePath: "request.json() -> query"
+      }
+    ];
+
+    const terminal = formatTerminal(result);
+
+    expect(terminal).toContain("Why: API routes that consume user input should validate the input.");
+    expect(terminal).toContain("Context reason: matched Next.js API route path");
+    expect(terminal).toContain("Evidence path: request.json() -> query");
+  });
+
   it("renders json reports", () => {
     const result = createScanResultSkeleton("demo-app");
 
@@ -102,7 +121,26 @@ describe("formatSummary", () => {
     expect(formatReport(result, "json")).not.toContain(secretEvidence);
     expect(formatTerminal(result)).not.toContain(secretEvidence);
     expect(formatMarkdown(result)).not.toContain(secretEvidence);
+    expect(formatGithub(result)).not.toContain(secretEvidence);
+    expect(formatSarif(result)).not.toContain(secretEvidence);
     expect(result.findings[0].evidence).toBe(secretEvidence);
+  });
+
+  it("preserves finding explanation metadata in JSON reports", () => {
+    const result = createScanResultSkeleton("demo-app");
+    result.findings = [
+      {
+        ...createContextFinding(),
+        evidencePath: "request.json() -> query"
+      }
+    ];
+
+    expect(JSON.parse(formatReport(result, "json")).findings[0]).toMatchObject({
+      context: "api-code",
+      contextReason: "matched Next.js API route path",
+      description: "API routes that consume user input should validate the input.",
+      evidencePath: "request.json() -> query"
+    });
   });
 
   it("renders markdown reports", () => {
@@ -191,6 +229,30 @@ describe("formatSummary", () => {
     const markdownReport = formatMarkdown(result);
 
     expect(markdownReport).toContain("- Context: `api-code`");
+  });
+
+  it("renders finding explanations and bounded evidence in markdown and GitHub reports", () => {
+    const result = createScanResultSkeleton("demo-app");
+    result.findings = [
+      {
+        ...createContextFinding(),
+        evidence: "db.query(sql)",
+        evidencePath: "request.json() -> query"
+      }
+    ];
+
+    const markdownReport = formatMarkdown(result);
+    const githubReport = formatGithub(result);
+
+    for (const report of [markdownReport, githubReport]) {
+      expect(report).toContain("Why: API routes that consume user input should validate the input.");
+      expect(report).toContain("Context reason: matched Next.js API route path");
+      expect(report).toContain("Evidence path: ");
+      expect(report).toContain("request.json() -> query");
+    }
+
+    expect(markdownReport).toContain("db.query(sql)");
+    expect(githubReport).not.toContain("db.query(sql)");
   });
 
   it("renders SARIF reports with the minimum top-level structure", () => {
@@ -318,6 +380,7 @@ describe("formatSummary", () => {
         context: "api-code",
         contextReason: "matched Next.js API route path",
         nextSecureCheckFindingId: "finding-1",
+        whyReported: "A secret-like value appears in source code.",
         evidenceRedacted: true,
         evidencePath: "request.json() -> apiKey"
       }

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -50,6 +50,11 @@ export function formatTerminal(result: ScanResult): string {
       const location = `${finding.filePath}${finding.line ? `:${finding.line}` : ""}`;
       lines.push(`- ${location}`);
       lines.push(`  ${finding.title} [${finding.ruleId}, confidence: ${finding.confidence}, context: ${formatContext(finding)}]`);
+      lines.push(`  Why: ${formatInlineText(finding.description)}`);
+      lines.push(`  Context reason: ${formatInlineText(formatContextReason(finding))}`);
+      if (finding.evidencePath) {
+        lines.push(`  Evidence path: ${formatInlineText(finding.evidencePath)}`);
+      }
       const evidence = redactFindingEvidence(finding);
       if (evidence) {
         lines.push(`  Evidence: ${evidence}`);
@@ -125,9 +130,14 @@ export function formatMarkdown(result: ScanResult): string {
       lines.push(`- Rule: \`${finding.ruleId}\``);
       lines.push(`- Confidence: \`${finding.confidence}\``);
       lines.push(`- Context: \`${formatContext(finding)}\``);
+      lines.push(`- Why: ${formatInlineText(finding.description)}`);
+      lines.push(`- Context reason: ${formatInlineText(formatContextReason(finding))}`);
+      if (finding.evidencePath) {
+        lines.push(`- Evidence path: \`${escapeBackticks(formatInlineText(finding.evidencePath))}\``);
+      }
       const evidence = redactFindingEvidence(finding);
       if (evidence) {
-        lines.push(`- Evidence: \`${evidence.replaceAll("`", "'")}\``);
+        lines.push(`- Evidence: \`${escapeBackticks(evidence)}\``);
       }
       lines.push(`- Recommendation: ${finding.recommendation}`);
     }
@@ -177,6 +187,11 @@ export function formatGithub(result: ScanResult): string {
     const findings = result.findings.filter((finding) => finding.severity === severity);
     for (const finding of findings) {
       lines.push(`- **${finding.severity}** \`${escapeBackticks(finding.ruleId)}\` at \`${escapeBackticks(formatLocation(finding))}\`: ${finding.recommendation}`);
+      lines.push(`  - Why: ${formatInlineText(finding.description)}`);
+      lines.push(`  - Context reason: ${formatInlineText(formatContextReason(finding))}`);
+      if (finding.evidencePath) {
+        lines.push(`  - Evidence path: \`${escapeBackticks(formatInlineText(finding.evidencePath))}\``);
+      }
     }
   }
 
@@ -233,8 +248,9 @@ export function formatSarif(result: ScanResult): string {
             category: finding.category,
             confidence: finding.confidence,
             context: finding.context ?? "unknown",
-            contextReason: finding.contextReason ?? "no context metadata available",
+            contextReason: formatContextReason(finding),
             nextSecureCheckFindingId: finding.id,
+            whyReported: formatInlineText(finding.description),
             evidenceRedacted: isSecretFinding(finding),
             ...(finding.evidencePath ? { evidencePath: finding.evidencePath } : {})
           }
@@ -485,6 +501,14 @@ function compareText(left: string, right: string): number {
 
 function formatContext(finding: ScanResult["findings"][number]): string {
   return finding.context ?? "unknown";
+}
+
+function formatContextReason(finding: ScanResult["findings"][number]): string {
+  return finding.contextReason ?? "no context metadata available";
+}
+
+function formatInlineText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
 }
 
 function escapeBackticks(value: string): string {


### PR DESCRIPTION
Closes #18

## Summary
- Add Why, context reason, and proven bounded videncePath to detailed terminal and Markdown reports.
- Keep GitHub output compact with explanation metadata in the existing recommendations details; raw evidence remains omitted.
- Preserve JSON/SARIF compatibility, add normalized SARIF whyReported, and extend web JSON/Markdown export metadata.
- Document false-positive and false-negative boundaries in xplain <rule-id> and add the Phase 16 validation note.

## Verification
- pnpm test — 366 package tests, 147 web tests, 513 total
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm release:gate — fixtures, privacy, determinism, summary, pack dry-run, and 100/1,000-file benchmarks

The README demo GIF remains unchanged; final media refresh belongs to the v0.5 release work in #20.